### PR TITLE
feat: add geometry and SVG utility modules

### DIFF
--- a/siteplan/geometry.py
+++ b/siteplan/geometry.py
@@ -1,0 +1,60 @@
+from dataclasses import dataclass
+
+
+@dataclass
+class Point:
+    """A 2D point."""
+
+    x: float
+    y: float
+
+
+@dataclass
+class Size:
+    """Width and height container."""
+
+    width: float
+    height: float
+
+
+@dataclass
+class Rectangle:
+    """Axis aligned rectangle."""
+
+    origin: Point
+    size: Size
+
+    @property
+    def x(self) -> float:
+        return self.origin.x
+
+    @property
+    def y(self) -> float:
+        return self.origin.y
+
+    @property
+    def width(self) -> float:
+        return self.size.width
+
+    @property
+    def height(self) -> float:
+        return self.size.height
+
+    @property
+    def right(self) -> float:
+        return self.x + self.width
+
+    @property
+    def bottom(self) -> float:
+        return self.y + self.height
+
+    def translate(self, dx: float, dy: float) -> "Rectangle":
+        """Return a translated copy of the rectangle."""
+        return Rectangle(Point(self.x + dx, self.y + dy), Size(self.width, self.height))
+
+    def scale(self, factor: float) -> "Rectangle":
+        """Return a uniformly scaled copy of the rectangle."""
+        return Rectangle(
+            Point(self.x * factor, self.y * factor),
+            Size(self.width * factor, self.height * factor),
+        )

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from typing import Iterable, Mapping
+
+from .geometry import Point, Rectangle
+
+
+SVG_NS = "http://www.w3.org/2000/svg"
+
+
+def _attrs_to_str(attrs: Mapping[str, object]) -> str:
+    """Convert attribute dictionary to a string for tag construction."""
+    return " ".join(f"{key}='{value}'" for key, value in attrs.items())
+
+
+def svg_tag(name: str, self_close: bool = False, **attrs: object) -> str:
+    """Generate a generic SVG tag."""
+    attr_str = _attrs_to_str(attrs)
+    if self_close:
+        return f"<{name} {attr_str} />"
+    return f"<{name} {attr_str}>"
+
+
+def svg_close(name: str) -> str:
+    """Return a closing tag for *name*."""
+    return f"</{name}>"
+
+
+def svg_rect(rect: Rectangle, **attrs: object) -> str:
+    """Generate a ``<rect>`` element from ``Rectangle``."""
+    rect_attrs = {
+        "x": rect.x,
+        "y": rect.y,
+        "width": rect.width,
+        "height": rect.height,
+    }
+    rect_attrs.update(attrs)
+    return svg_tag("rect", self_close=True, **rect_attrs)
+
+
+def svg_line(p1: Point, p2: Point, **attrs: object) -> str:
+    """Generate a ``<line>`` element."""
+    line_attrs = {"x1": p1.x, "y1": p1.y, "x2": p2.x, "y2": p2.y}
+    line_attrs.update(attrs)
+    return svg_tag("line", self_close=True, **line_attrs)
+
+
+def svg_polygon(points: Iterable[Point], **attrs: object) -> str:
+    """Generate a ``<polygon>`` element from a sequence of points."""
+    point_str = " ".join(f"{p.x},{p.y}" for p in points)
+    poly_attrs = {"points": point_str}
+    poly_attrs.update(attrs)
+    return svg_tag("polygon", self_close=True, **poly_attrs)
+
+
+def svg_header(width: float, height: float, **attrs: object) -> str:
+    """Return the opening ``<svg>`` tag with namespace and size."""
+    header_attrs = {"xmlns": SVG_NS, "width": width, "height": height}
+    header_attrs.update(attrs)
+    return svg_tag("svg", **header_attrs)
+
+
+def svg_footer() -> str:
+    """Return closing ``</svg>`` tag."""
+    return svg_close("svg")

--- a/tests/test_svg_writer.py
+++ b/tests/test_svg_writer.py
@@ -1,0 +1,32 @@
+from siteplan.geometry import Point, Rectangle, Size
+from siteplan.svg_writer import svg_footer, svg_header, svg_line, svg_polygon, svg_rect
+
+
+def test_svg_rect():
+    rect = Rectangle(Point(0, 0), Size(10, 5))
+    tag = svg_rect(rect, fill="none")
+    assert tag == "<rect x='0' y='0' width='10' height='5' fill='none' />"
+
+
+def test_svg_line():
+    p1 = Point(0, 0)
+    p2 = Point(5, 5)
+    tag = svg_line(p1, p2, stroke="black")
+    assert tag == "<line x1='0' y1='0' x2='5' y2='5' stroke='black' />"
+
+
+def test_svg_polygon():
+    points = [Point(0, 0), Point(1, 0), Point(1, 1)]
+    tag = svg_polygon(points, stroke="black", fill="none")
+    assert tag == "<polygon points='0,0 1,0 1,1' stroke='black' fill='none' />"
+
+
+def test_svg_header_footer():
+    header = svg_header(100, 50)
+    footer = svg_footer()
+    assert (
+        header.startswith("<svg")
+        and "width='100'" in header
+        and "height='50'" in header
+    )
+    assert footer == "</svg>"


### PR DESCRIPTION
## Summary
- add `geometry` with simple primitives
- add `svg_writer` helpers to create SVG tags
- test SVG tag generators

## Testing
- `python -m pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68619a3e59cc83309e29230117153a09