### PR TITLE
feat: implement duplex + ADU layout generator

### DIFF
--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List
+
+SCALE = 10  # pixels per foot
+
+
+@dataclass
+class Rectangle:
+    """Simple rectangle geometry in feet."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+
+    def to_pixels(self) -> "Rectangle":
+        """Return a rectangle scaled to pixels."""
+        return Rectangle(
+            x=self.x * SCALE,
+            y=self.y * SCALE,
+            width=self.width * SCALE,
+            height=self.height * SCALE,
+        )
+
+
+@dataclass
+class LotSpec:
+    width: float
+    depth: float
+    front_setback: float
+    rear_setback: float
+    side_setback: float
+
+
+@dataclass
+class BuildingSpec:
+    width: float
+    depth: float
+
+
+@dataclass
+class Layout:
+    lot: Rectangle
+    duplex: Rectangle
+    adu: Rectangle
+    parking: List[Rectangle]
+
+    def to_pixels(self) -> "Layout":
+        return Layout(
+            lot=self.lot.to_pixels(),
+            duplex=self.duplex.to_pixels(),
+            adu=self.adu.to_pixels(),
+            parking=[p.to_pixels() for p in self.parking],
+        )
+
+
+def compute_layout(
+    lot: LotSpec, duplex: BuildingSpec, adu: BuildingSpec, parking_depth: float = 20
+) -> Layout:
+    """Compute placement for duplex, ADU, and parking within a lot.
+
+    Parameters
+    ----------
+    lot: LotSpec
+        Dimensions of the lot and setbacks in feet.
+    duplex: BuildingSpec
+        Size of the duplex building in feet.
+    adu: BuildingSpec
+        Size of the ADU in feet.
+    parking_depth: float
+        Depth of the parking pad in feet.
+    """
+    lot_rect = Rectangle(0, 0, lot.width, lot.depth)
+
+    duplex_x = lot.side_setback
+    duplex_y = lot.front_setback
+    duplex_rect = Rectangle(duplex_x, duplex_y, duplex.width, duplex.depth)
+
+    adu_x = lot.width - lot.side_setback - adu.width
+    adu_y = lot.depth - lot.rear_setback - adu.depth
+    adu_rect = Rectangle(adu_x, adu_y, adu.width, adu.depth)
+
+    parking_width = duplex.width / 2
+    parking1 = Rectangle(
+        duplex_x, duplex_y - parking_depth, parking_width, parking_depth
+    )
+    parking2 = Rectangle(
+        duplex_x + parking_width, duplex_y - parking_depth, parking_width, parking_depth
+    )
+
+    return Layout(lot_rect, duplex_rect, adu_rect, [parking1, parking2])

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,23 @@
+import pytest
+
+from siteplan.layout import (
+    LotSpec,
+    BuildingSpec,
+    compute_layout,
+    Rectangle,
+)
+
+
+def test_compute_layout_basic():
+    lot = LotSpec(
+        width=50, depth=100, front_setback=25, rear_setback=10, side_setback=5
+    )
+    duplex = BuildingSpec(width=30, depth=40)
+    adu = BuildingSpec(width=20, depth=20)
+
+    layout = compute_layout(lot, duplex, adu)
+
+    assert layout.duplex == Rectangle(5, 25, 30, 40)
+    assert layout.adu == Rectangle(25, 70, 20, 20)
+    assert layout.parking[0] == Rectangle(5, 5, 15, 20)
+    assert layout.parking[1] == Rectangle(20, 5, 15, 20)


### PR DESCRIPTION
## Summary
- add geometry primitives and layout computation
- include basic unit test for layout

## Testing
- `flake8 siteplan tests` *(fails: command not found)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619a437cf483309461afeac1e98f88