### PR TITLE
feat: add CLI for siteplan SVG rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,14 @@
+# Siteplan
+
+This project provides a simple generator for a duplex and ADU site plan.
+
+## Command Line Interface
+
+Use the CLI to generate an SVG site plan:
+
+```bash
+python -m siteplan.cli --output output/duplex_siteplan.svg
+```
+
+The SVG will be written to the given path. The default output is
+`output/duplex_siteplan.svg`.

--- a/siteplan/__init__.py
+++ b/siteplan/__init__.py
@@ -1,0 +1,5 @@
+"""Siteplan package."""
+
+from . import layout, svg_writer
+
+__all__ = ["layout", "svg_writer"]

--- a/siteplan/cli.py
+++ b/siteplan/cli.py
@@ -1,0 +1,23 @@
+import argparse
+from pathlib import Path
+
+from . import layout, svg_writer
+
+
+def main(argv=None) -> None:
+    parser = argparse.ArgumentParser(description="Generate duplex + ADU site plan")
+    parser.add_argument(
+        "--output",
+        default="output/duplex_siteplan.svg",
+        help="Path to output SVG file",
+    )
+    args = parser.parse_args(argv)
+
+    shapes = layout.generate_siteplan()
+    output = Path(args.output)
+    svg_writer.write_svg(shapes, output)
+    print(f"SVG written to {output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -1,0 +1,51 @@
+from dataclasses import dataclass
+from typing import List
+
+
+@dataclass
+class Rect:
+    """Represents a rectangle in feet."""
+
+    x: float
+    y: float
+    width: float
+    height: float
+    fill: str = "none"
+    stroke: str = "black"
+
+
+def generate_siteplan() -> List[Rect]:
+    """Return rectangles representing a simple duplex and ADU site plan."""
+    shapes: List[Rect] = []
+
+    # Lot dimensions (feet)
+    lot_width, lot_height = 50.0, 100.0
+    shapes.append(Rect(0, 0, lot_width, lot_height, fill="lightgreen"))
+
+    # Duplex units
+    duplex_width, duplex_height = 20.0, 40.0
+    padding = 5.0
+    shapes.append(Rect(padding, padding, duplex_width, duplex_height, fill="gray"))
+    shapes.append(
+        Rect(
+            padding,
+            lot_height - duplex_height - padding,
+            duplex_width,
+            duplex_height,
+            fill="gray",
+        )
+    )
+
+    # Accessory Dwelling Unit (ADU)
+    adu_width, adu_height = 15.0, 20.0
+    shapes.append(
+        Rect(
+            lot_width - adu_width - padding,
+            (lot_height - adu_height) / 2,
+            adu_width,
+            adu_height,
+            fill="brown",
+        )
+    )
+
+    return shapes

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -1,0 +1,38 @@
+from pathlib import Path
+from typing import Iterable
+import xml.etree.ElementTree as ET
+
+from .layout import Rect
+
+
+def write_svg(shapes: Iterable[Rect], path: Path, scale: float = 10.0) -> None:
+    """Write shapes to an SVG file at the given path."""
+    path = Path(path)
+    width = max(r.x + r.width for r in shapes) * scale
+    height = max(r.y + r.height for r in shapes) * scale
+
+    root = ET.Element(
+        "svg",
+        xmlns="http://www.w3.org/2000/svg",
+        width=str(width),
+        height=str(height),
+    )
+
+    for rect in shapes:
+        ET.SubElement(
+            root,
+            "rect",
+            {
+                "x": str(rect.x * scale),
+                "y": str(rect.y * scale),
+                "width": str(rect.width * scale),
+                "height": str(rect.height * scale),
+                "fill": rect.fill,
+                "stroke": rect.stroke,
+            },
+        )
+
+    tree = ET.ElementTree(root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("wb") as f:
+        tree.write(f)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,7 @@
+from siteplan import layout
+
+
+def test_generate_siteplan_rectangles():
+    shapes = layout.generate_siteplan()
+    assert isinstance(shapes, list)
+    assert len(shapes) >= 4


### PR DESCRIPTION
## Summary
- implement simple siteplan package
- add CLI for generating siteplan SVGs
- add layout generation and SVG writer utilities
- document CLI usage
- add basic test for layout generator

## Testing
- `black -q .`
- `flake8` *(fails: command not found)*
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68619a48bd208330b70bb4eeb2ffcfde