### PR TITLE
test: add pytest coverage and usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Siteplan
+
+Simple generator that outputs an SVG site plan for a duplex and ADU.
+
+## Installation
+
+```bash
+python -m venv venv
+source venv/bin/activate
+pip install -r requirements.txt
+```
+
+## Generate SVG
+
+```bash
+python main.py --output output/siteplan.svg
+```
+
+The file will be saved to `output/siteplan.svg`.
+
+## Run tests
+
+```bash
+pytest
+```

--- a/geometry.py
+++ b/geometry.py
@@ -1,0 +1,22 @@
+SCALE = 10
+
+
+def ft_to_px(feet: float) -> float:
+    """Convert feet to pixels using SCALE."""
+    return feet * SCALE
+
+
+def rect_area(width_ft: float, height_ft: float) -> float:
+    """Return area in square feet."""
+    return width_ft * height_ft
+
+
+def rect_pixels(origin_ft, width_ft: float, height_ft: float):
+    """Return rectangle params in pixels (x, y, w, h)."""
+    x_ft, y_ft = origin_ft
+    return (
+        ft_to_px(x_ft),
+        ft_to_px(y_ft),
+        ft_to_px(width_ft),
+        ft_to_px(height_ft),
+    )

--- a/layout.py
+++ b/layout.py
@@ -1,0 +1,41 @@
+import os
+from typing import Dict, Tuple
+
+from geometry import ft_to_px, rect_pixels
+
+DUPLEX_SIZE = (30, 40)  # width_ft, height_ft
+ADU_SIZE = (20, 20)
+SPACING = 10  # feet between buildings
+
+
+def layout_positions() -> Dict[str, Tuple[float, float, float, float]]:
+    """Return pixel rectangles for duplex and ADU."""
+    duplex_origin = (0, 0)
+    adu_origin = (DUPLEX_SIZE[0] + SPACING, 0)
+    return {
+        "duplex": rect_pixels(duplex_origin, *DUPLEX_SIZE),
+        "adu": rect_pixels(adu_origin, *ADU_SIZE),
+    }
+
+
+def generate_svg(path: str = "output/siteplan.svg") -> None:
+    """Generate simple SVG drawing to *path*."""
+    positions = layout_positions()
+    width_ft = DUPLEX_SIZE[0] + SPACING + ADU_SIZE[0]
+    height_ft = max(DUPLEX_SIZE[1], ADU_SIZE[1])
+    width_px = ft_to_px(width_ft)
+    height_px = ft_to_px(height_ft)
+
+    lines = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width_px}" height="{height_px}">'
+    ]
+    for name, (x, y, w, h) in positions.items():
+        color = "blue" if name == "duplex" else "green"
+        lines.append(
+            f'<rect id="{name}" x="{x}" y="{y}" width="{w}" height="{h}" fill="{color}" />'
+        )
+    lines.append("</svg>")
+
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        f.write("\n".join(lines))

--- a/main.py
+++ b/main.py
@@ -1,0 +1,16 @@
+import argparse
+
+from layout import generate_svg
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate site plan SVG")
+    parser.add_argument(
+        "--output", default="output/siteplan.svg", help="Path to output SVG"
+    )
+    args = parser.parse_args()
+    generate_svg(args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_geometry.py
+++ b/tests/test_geometry.py
@@ -1,0 +1,16 @@
+import os
+
+import geometry
+
+
+def test_ft_to_px():
+    assert geometry.ft_to_px(5) == 50
+
+
+def test_rect_area():
+    assert geometry.rect_area(3, 4) == 12
+
+
+def test_rect_pixels():
+    rect = geometry.rect_pixels((1, 2), 3, 4)
+    assert rect == (10, 20, 30, 40)

--- a/tests/test_layout.py
+++ b/tests/test_layout.py
@@ -1,0 +1,17 @@
+import os
+
+import layout
+
+
+def test_layout_positions():
+    positions = layout.layout_positions()
+    duplex = positions["duplex"]
+    adu = positions["adu"]
+    # ADU should be to the right of duplex with spacing of 10ft (100px)
+    assert adu[0] - (duplex[0] + duplex[2]) == layout.ft_to_px(layout.SPACING)
+
+
+def test_generate_svg_file_output(tmp_path):
+    out_file = tmp_path / "plan.svg"
+    layout.generate_svg(str(out_file))
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- add simple geometry and layout modules
- generate an SVG via CLI
- provide pytest unit tests
- document install, usage, and test commands

## Testing
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: ModuleNotFoundError)*
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68619a523d9c83308266446d6334c9d9