### PR TITLE
Add prompt-driven layout and example generator

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,7 +1,3 @@
 [flake8]
 max-line-length = 88
-<<<<<<< HEAD
 extend-ignore = E203,W503
-=======
-extend-ignore = E203
->>>>>>> origin/main

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Generate a simple site plan SVG:
 python -m siteplan.cli output/siteplan.svg
 ```
 
+You can also provide prompt instructions:
+
+```bash
+python -m siteplan.cli output/siteplan.svg --prompt "place house 20x30 at 0,0"
+```
+
+Or read the prompt from a file using the `@` prefix:
+
+```bash
+python -m siteplan.cli output/siteplan.svg --prompt @prompt.txt
+```
+
 The output SVG will be written to the path provided (default `output/siteplan.svg`).
 
 ## Running Tests

--- a/examples/duplex_adu.py
+++ b/examples/duplex_adu.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+from siteplan.layout import Layout
+from siteplan.optimizer import separate_shapes
+from siteplan.prompt_parser import parse_prompt
+
+PROMPT = """
+place duplex 40x30 at 0,0
+place adu 20x20 at 50,0
+"""
+
+
+def main() -> None:
+    layout = Layout()
+    for rect in parse_prompt(PROMPT):
+        layout.add_shape(rect)
+    separate_shapes(layout)
+    layout.export_svg(Path("output/examples/duplex_adu.svg"))
+
+
+if __name__ == "__main__":
+    main()

--- a/siteplan/cli.py
+++ b/siteplan/cli.py
@@ -4,12 +4,21 @@ from pathlib import Path
 
 from .geometry import Rectangle
 from .layout import Layout
+from .optimizer import separate_shapes
+from .prompt_parser import parse_prompt
 
 
-def main(output: str = "output/siteplan.svg") -> None:
+def main(output: str = "output/siteplan.svg", prompt: str | None = None) -> None:
     layout = Layout()
-    layout.add_shape(Rectangle(0, 0, 100, 50))
-    layout.add_shape(Rectangle(120, 0, 80, 40))
+    if prompt:
+        rects = parse_prompt(prompt)
+        for r in rects:
+            layout.add_shape(r)
+    else:
+        layout.add_shape(Rectangle(0, 0, 100, 50))
+        layout.add_shape(Rectangle(120, 0, 80, 40))
+
+    separate_shapes(layout)
     layout.export_svg(Path(output))
 
 
@@ -23,5 +32,17 @@ if __name__ == "__main__":
         default="output/siteplan.svg",
         help="Output SVG path",
     )
+    parser.add_argument(
+        "--prompt",
+        help="Prompt text or @path to file containing prompt",
+    )
     args = parser.parse_args()
-    main(args.output)
+
+    prompt_text = None
+    if args.prompt:
+        if args.prompt.startswith("@"):
+            prompt_text = Path(args.prompt[1:]).read_text()
+        else:
+            prompt_text = args.prompt
+
+    main(args.output, prompt_text)

--- a/siteplan/geometry.py
+++ b/siteplan/geometry.py
@@ -1,14 +1,17 @@
 from math import sqrt
 
+
 class Point:
     def __init__(self, x: float, y: float):
         self.x = x
         self.y = y
 
+
 class Size:
     def __init__(self, width: float, height: float):
         self.width = width
         self.height = height
+
 
 class Rectangle:
     def __init__(self, *args):
@@ -29,6 +32,7 @@ class Rectangle:
         self.x += dx
         self.y += dy
         return self
+
 
 def distance(a: tuple, b: tuple) -> float:
     return sqrt((b[0] - a[0]) ** 2 + (b[1] - a[1]) ** 2)

--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -5,6 +5,7 @@ from typing import List
 from pathlib import Path
 
 from .geometry import Rectangle
+from .svg_writer import svg_footer, svg_grid, svg_header, svg_rect, svg_text
 
 
 @dataclass
@@ -14,15 +15,33 @@ class Layout:
     def add_shape(self, shape: Rectangle) -> None:
         self.shapes.append(shape)
 
-    def export_svg(self, path: Path) -> None:
+    def export_svg(self, path: Path, scale: float = 10) -> None:
+        """Export layout as scaled SVG with gridlines and basic dimensions."""
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
+
+        max_x = max((r.x + r.width for r in self.shapes), default=0)
+        max_y = max((r.y + r.height for r in self.shapes), default=0)
+
+        width = max_x + 20
+        height = max_y + 20
+
         with path.open("w", encoding="utf-8") as f:
-            f.write('<svg xmlns="http://www.w3.org/2000/svg">\n')
+            f.write(svg_header(width, height) + "\n")
+            f.write(svg_grid(width, height) + "\n")
             for rect in self.shapes:
+                f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
+                label_x = rect.x + rect.width / 2
+                label_y = rect.y - 5
+                dims = f"{rect.width/scale}x{rect.height/scale} ft"
                 f.write(
-                    f'  <rect x="{rect.x}" y="{rect.y}" '
-                    f'width="{rect.width}" height="{rect.height}" '
-                    'fill="none" stroke="black"/>\n'
+                    svg_text(
+                        label_x,
+                        label_y,
+                        dims,
+                        fill="black",
+                        **{"text-anchor": "middle", "font-size": 12},
+                    )
+                    + "\n"
                 )
-            f.write("</svg>\n")
+            f.write(svg_footer() + "\n")

--- a/siteplan/optimizer.py
+++ b/siteplan/optimizer.py
@@ -1,0 +1,14 @@
+from __future__ import annotations
+
+from .layout import Layout
+
+
+def separate_shapes(layout: Layout, min_dist: float = 10) -> Layout:
+    """Ensure shapes do not overlap by translating them if needed."""
+    for i, rect in enumerate(layout.shapes):
+        for other in layout.shapes[i + 1 :]:
+            overlap_x = rect.x + rect.width + min_dist - other.x
+            overlap_y = rect.y + rect.height + min_dist - other.y
+            if overlap_x > 0 and overlap_y > 0:
+                other.move(overlap_x, overlap_y)
+    return layout

--- a/siteplan/prompt_parser.py
+++ b/siteplan/prompt_parser.py
@@ -1,0 +1,23 @@
+from __future__ import annotations
+
+from typing import List
+
+from .geometry import Rectangle
+
+
+def parse_prompt(text: str) -> List[Rectangle]:
+    """Parse a structured prompt and return rectangles scaled 1ft = 10px."""
+    shapes: List[Rectangle] = []
+    lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+    for line in lines:
+        parts = line.split()
+        if len(parts) != 5 or parts[0].lower() != "place" or parts[3].lower() != "at":
+            raise ValueError(f"Invalid instruction: {line}")
+        dims = parts[2].lower().split("x")
+        if len(dims) != 2:
+            raise ValueError(f"Invalid dimensions in: {line}")
+        width_ft, height_ft = map(float, dims)
+        x_ft, y_ft = map(float, parts[4].split(","))
+        rect = Rectangle(x_ft * 10, y_ft * 10, width_ft * 10, height_ft * 10)
+        shapes.append(rect)
+    return shapes

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -53,6 +53,28 @@ def svg_polygon(points: Iterable[Point], **attrs: object) -> str:
     return svg_tag("polygon", self_close=True, **poly_attrs)
 
 
+def svg_text(x: float, y: float, text: str, **attrs: object) -> str:
+    """Generate a ``<text>`` element."""
+    text_attrs = {"x": x, "y": y}
+    text_attrs.update(attrs)
+    attr_str = _attrs_to_str(text_attrs)
+    return f"<text {attr_str}>{text}</text>"
+
+
+def svg_grid(width: float, height: float, spacing: float = 100) -> str:
+    """Generate light gridlines for the plan."""
+    lines = []
+    x = 0
+    while x <= width:
+        lines.append(svg_line(Point(x, 0), Point(x, height), stroke="#ddd"))
+        x += spacing
+    y = 0
+    while y <= height:
+        lines.append(svg_line(Point(0, y), Point(width, y), stroke="#ddd"))
+        y += spacing
+    return "\n".join(lines)
+
+
 def svg_header(width: float, height: float, **attrs: object) -> str:
     """Return the opening ``<svg>`` tag with namespace and size."""
     header_attrs = {"xmlns": SVG_NS, "width": width, "height": height}

--- a/tests/test_cli_prompt.py
+++ b/tests/test_cli_prompt.py
@@ -1,0 +1,19 @@
+from pathlib import Path
+import subprocess
+import sys
+
+
+def test_cli_with_prompt(tmp_path: Path):
+    out_file = tmp_path / "plan.svg"
+    cmd = [
+        sys.executable,
+        "-m",
+        "siteplan.cli",
+        str(out_file),
+        "--prompt",
+        "place house 10x10 at 0,0",
+    ]
+    subprocess.check_call(cmd)
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert "<rect" in content

--- a/tests/test_example_duplex_adu.py
+++ b/tests/test_example_duplex_adu.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_runs(tmp_path: Path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    # import module after changing directory so output is in tmp_path
+    module = importlib.import_module("examples.duplex_adu")
+    module.main()
+    svg = Path("output/examples/duplex_adu.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    assert "<rect" in content

--- a/tests/test_optimizer.py
+++ b/tests/test_optimizer.py
@@ -1,0 +1,12 @@
+from siteplan.geometry import Rectangle
+from siteplan.layout import Layout
+from siteplan.optimizer import separate_shapes
+
+
+def test_separate_shapes():
+    layout = Layout()
+    layout.add_shape(Rectangle(0, 0, 100, 50))
+    layout.add_shape(Rectangle(50, 25, 80, 40))
+    separate_shapes(layout, min_dist=10)
+    rect1, rect2 = layout.shapes
+    assert rect2.x >= rect1.x + rect1.width + 10

--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -1,0 +1,10 @@
+from siteplan.prompt_parser import parse_prompt
+
+
+def test_parse_single_instruction():
+    prompt = "place house 20x30 at 5,10"
+    rects = parse_prompt(prompt)
+    assert len(rects) == 1
+    rect = rects[0]
+    assert rect.x == 50 and rect.y == 100
+    assert rect.width == 200 and rect.height == 300

--- a/tests/test_svg_style.py
+++ b/tests/test_svg_style.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+from siteplan.geometry import Rectangle
+from siteplan.layout import Layout
+
+
+def test_svg_with_grid(tmp_path: Path):
+    layout = Layout()
+    layout.add_shape(Rectangle(0, 0, 100, 50))
+    out_file = tmp_path / "plan.svg"
+    layout.export_svg(out_file)
+    content = out_file.read_text()
+    assert "<line" in content  # gridlines
+    assert "<text" in content  # dimension label


### PR DESCRIPTION
## Summary
- implement prompt parser for structured text
- add constraint-based optimizer for layout separation
- enhance SVG output with grid and dimensions
- update CLI for prompt-driven workflows
- include duplex + ADU example and supporting tests

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861af24b950833084e86d80a0e4eec2