### PR TITLE
Add placement orientation and setback parsing

### DIFF
--- a/examples/duplex_adu.py
+++ b/examples/duplex_adu.py
@@ -12,8 +12,8 @@ place adu 20x20 at 50,0
 
 def main() -> None:
     layout = Layout()
-    for rect in parse_prompt(PROMPT):
-        layout.add_shape(rect)
+    for placement in parse_prompt(PROMPT):
+        layout.add_shape(placement.rect)
     separate_shapes(layout)
     layout.export_svg(Path("output/examples/duplex_adu.svg"))
 

--- a/siteplan/cli.py
+++ b/siteplan/cli.py
@@ -11,9 +11,9 @@ from .prompt_parser import parse_prompt
 def main(output: str = "output/siteplan.svg", prompt: str | None = None) -> None:
     layout = Layout()
     if prompt:
-        rects = parse_prompt(prompt)
-        for r in rects:
-            layout.add_shape(r)
+        placements = parse_prompt(prompt)
+        for p in placements:
+            layout.add_shape(p.rect)
     else:
         layout.add_shape(Rectangle(0, 0, 100, 50))
         layout.add_shape(Rectangle(120, 0, 80, 40))

--- a/siteplan/prompt_parser.py
+++ b/siteplan/prompt_parser.py
@@ -1,23 +1,66 @@
 from __future__ import annotations
 
-from typing import List
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional
 
 from .geometry import Rectangle
 
 
-def parse_prompt(text: str) -> List[Rectangle]:
-    """Parse a structured prompt and return rectangles scaled 1ft = 10px."""
-    shapes: List[Rectangle] = []
+@dataclass
+class Placement:
+    """Rectangle placement details parsed from a prompt line."""
+
+    rect: Rectangle
+    facing: Optional[str] = None
+    setbacks: Dict[str, float] = field(default_factory=dict)
+
+
+def parse_prompt(text: str) -> List[Placement]:
+    """Parse a structured prompt and return rectangle placements."""
+
+    placements: List[Placement] = []
     lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+
     for line in lines:
         parts = line.split()
-        if len(parts) != 5 or parts[0].lower() != "place" or parts[3].lower() != "at":
+        if parts[0].lower() != "place" or "at" not in parts:
             raise ValueError(f"Invalid instruction: {line}")
+
+        try:
+            at_idx = parts.index("at")
+        except ValueError as exc:  # pragma: no cover - safeguard
+            raise ValueError(f"Invalid instruction: {line}") from exc
+
+        if at_idx != 3 or len(parts) < 5:
+            raise ValueError(f"Invalid instruction: {line}")
+
         dims = parts[2].lower().split("x")
         if len(dims) != 2:
             raise ValueError(f"Invalid dimensions in: {line}")
+
         width_ft, height_ft = map(float, dims)
-        x_ft, y_ft = map(float, parts[4].split(","))
+        x_ft, y_ft = map(float, parts[at_idx + 1].split(","))
+
+        facing: Optional[str] = None
+        setbacks: Dict[str, float] = {}
+
+        i = at_idx + 2
+        while i < len(parts):
+            token = parts[i].lower()
+            if token == "facing":
+                if i + 1 >= len(parts):
+                    raise ValueError(f"Missing direction after 'facing' in: {line}")
+                facing = parts[i + 1].lower()
+                i += 2
+            elif token in {"n", "s", "e", "w"}:
+                if i + 2 >= len(parts) or parts[i + 1].lower() != "setback":
+                    raise ValueError(f"Invalid setback syntax in: {line}")
+                setbacks[token] = float(parts[i + 2])
+                i += 3
+            else:
+                raise ValueError(f"Unknown token '{parts[i]}' in: {line}")
+
         rect = Rectangle(x_ft * 10, y_ft * 10, width_ft * 10, height_ft * 10)
-        shapes.append(rect)
-    return shapes
+        placements.append(Placement(rect, facing, setbacks))
+
+    return placements

--- a/tests/test_prompt_parser.py
+++ b/tests/test_prompt_parser.py
@@ -3,8 +3,19 @@ from siteplan.prompt_parser import parse_prompt
 
 def test_parse_single_instruction():
     prompt = "place house 20x30 at 5,10"
-    rects = parse_prompt(prompt)
-    assert len(rects) == 1
-    rect = rects[0]
+    placements = parse_prompt(prompt)
+    assert len(placements) == 1
+    p = placements[0]
+    rect = p.rect
     assert rect.x == 50 and rect.y == 100
     assert rect.width == 200 and rect.height == 300
+    assert p.facing is None
+    assert p.setbacks == {}
+
+
+def test_parse_with_options():
+    prompt = "place house 10x10 at 0,0 facing east n setback 5 w setback 3"
+    [p] = parse_prompt(prompt)
+    assert p.facing == "east"
+    assert p.setbacks["n"] == 5
+    assert p.setbacks["w"] == 3


### PR DESCRIPTION
## Summary
- extend `prompt_parser` with `Placement` dataclass
- support optional `facing` and setback keywords
- update CLI and example to use new dataclass
- expand prompt parser tests for new behavior

## Testing
- `black -q .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e1cc9ad88330ae2ad695a39a5c18