### PR TITLE
Add layout loading and append prompt options

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ Or read the prompt from a file using the `@` prefix:
 python -m siteplan.cli output/siteplan.svg --prompt @prompt.txt
 ```
 
+### Appending to an Existing Layout
+
+You can load a previously saved layout and add more shapes using
+`--append-prompt`. The layout file can be JSON or a Python pickle created with
+the `Layout.save` method.
+
+```bash
+python -m siteplan.cli output/siteplan.svg \
+    --load layout.json \
+    --append-prompt "place shed 10x10 at 50,0"
+```
+
+After applying the appended instructions the SVG at `output/siteplan.svg` will
+be overwritten with the updated drawing.
+
 The output SVG will be written to the path provided (default `output/siteplan.svg`).
 
 ## Running Tests

--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import List
 from pathlib import Path
+import json
+import pickle
 
 from .geometry import Rectangle
 from .svg_writer import svg_footer, svg_grid, svg_header, svg_rect, svg_text
@@ -45,3 +47,25 @@ class Layout:
                     + "\n"
                 )
             f.write(svg_footer() + "\n")
+
+    def save(self, path: Path) -> None:
+        path = Path(path)
+        if path.suffix == ".json":
+            data = {"shapes": [[r.x, r.y, r.width, r.height] for r in self.shapes]}
+            path.write_text(json.dumps(data))
+        else:
+            with path.open("wb") as f:
+                pickle.dump(self, f)
+
+    @classmethod
+    def load(cls, path: Path) -> "Layout":
+        path = Path(path)
+        if path.suffix == ".json":
+            data = json.loads(path.read_text())
+            layout = cls()
+            for vals in data.get("shapes", []):
+                layout.add_shape(Rectangle(*vals))
+            return layout
+        else:
+            with path.open("rb") as f:
+                return pickle.load(f)

--- a/tests/test_cli_prompt.py
+++ b/tests/test_cli_prompt.py
@@ -2,6 +2,9 @@ from pathlib import Path
 import subprocess
 import sys
 
+from siteplan.geometry import Rectangle
+from siteplan.layout import Layout
+
 
 def test_cli_with_prompt(tmp_path: Path):
     out_file = tmp_path / "plan.svg"
@@ -17,3 +20,26 @@ def test_cli_with_prompt(tmp_path: Path):
     assert out_file.exists()
     content = out_file.read_text()
     assert "<rect" in content
+
+
+def test_cli_append_prompt(tmp_path: Path):
+    layout = Layout()
+    layout.add_shape(Rectangle(0, 0, 10, 10))
+    layout_file = tmp_path / "layout.json"
+    layout.save(layout_file)
+
+    out_file = tmp_path / "plan.svg"
+    cmd = [
+        sys.executable,
+        "-m",
+        "siteplan.cli",
+        str(out_file),
+        "--load",
+        str(layout_file),
+        "--append-prompt",
+        "place garage 5x5 at 20,0",
+    ]
+    subprocess.check_call(cmd)
+    assert out_file.exists()
+    content = out_file.read_text()
+    assert content.count("<rect") == 2


### PR DESCRIPTION
## Summary
- support saving/loading Layout objects from JSON or pickle
- extend CLI with `--load` and `--append-prompt` options
- document how to append to an existing layout
- test CLI append prompt workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1d068a483309bf652ae2db83cb8