### PR TITLE
Add svg boundary and dimension helpers

### DIFF
--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -7,7 +7,14 @@ import json
 import pickle
 
 from .geometry import Rectangle
-from .svg_writer import svg_footer, svg_grid, svg_header, svg_rect, svg_text
+from .svg_writer import (
+    svg_boundary,
+    svg_dimensions,
+    svg_footer,
+    svg_grid,
+    svg_header,
+    svg_rect,
+)
 
 
 @dataclass
@@ -33,19 +40,8 @@ class Layout:
             f.write(svg_grid(width, height) + "\n")
             for rect in self.shapes:
                 f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
-                label_x = rect.x + rect.width / 2
-                label_y = rect.y - 5
-                dims = f"{rect.width/scale}x{rect.height/scale} ft"
-                f.write(
-                    svg_text(
-                        label_x,
-                        label_y,
-                        dims,
-                        fill="black",
-                        **{"text-anchor": "middle", "font-size": 12},
-                    )
-                    + "\n"
-                )
+                f.write(svg_boundary(rect) + "\n")
+                f.write(svg_dimensions(rect, scale) + "\n")
             f.write(svg_footer() + "\n")
 
     def save(self, path: Path) -> None:

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -61,6 +61,58 @@ def svg_text(x: float, y: float, text: str, **attrs: object) -> str:
     return f"<text {attr_str}>{text}</text>"
 
 
+def svg_boundary(rect: Rectangle, offset: float = 5, **attrs: object) -> str:
+    """Generate a dashed boundary polygon around *rect*."""
+    points = [
+        Point(rect.x - offset, rect.y - offset),
+        Point(rect.x + rect.width + offset, rect.y - offset),
+        Point(rect.x + rect.width + offset, rect.y + rect.height + offset),
+        Point(rect.x - offset, rect.y + rect.height + offset),
+    ]
+    boundary_attrs = {"fill": "none", "stroke": "red", "stroke-dasharray": "4 2"}
+    boundary_attrs.update(attrs)
+    return svg_polygon(points, **boundary_attrs)
+
+
+def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
+    """Return simple width/height dimension lines and labels for *rect*."""
+    elements = []
+    top_y = rect.y - 10
+    left_x = rect.x - 10
+    # dimension lines
+    elements.append(
+        svg_line(
+            Point(rect.x, top_y), Point(rect.x + rect.width, top_y), stroke="black"
+        )
+    )
+    elements.append(
+        svg_line(
+            Point(left_x, rect.y), Point(left_x, rect.y + rect.height), stroke="black"
+        )
+    )
+    # labels
+    elements.append(
+        svg_text(
+            rect.x + rect.width / 2,
+            top_y - 2,
+            f"{rect.width/scale} ft",
+            fill="black",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    elements.append(
+        svg_text(
+            left_x - 2,
+            rect.y + rect.height / 2,
+            f"{rect.height/scale} ft",
+            fill="black",
+            transform=f"rotate(-90 {left_x - 2},{rect.y + rect.height / 2})",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    return "\n".join(elements)
+
+
 def svg_grid(width: float, height: float, spacing: float = 100) -> str:
     """Generate light gridlines for the plan."""
     lines = []


### PR DESCRIPTION
## Summary
- implement `svg_boundary` and `svg_dimensions` helpers
- integrate these helpers into `Layout.export_svg`

## Testing
- `flake8 siteplan tests`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861e54cc89083308a18ff75840d277c