### PR TITLE
Add sample site plan SVG

### DIFF
--- a/examples/siteplan_lot1.py
+++ b/examples/siteplan_lot1.py
@@ -1,0 +1,160 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from siteplan.geometry import Point, Rectangle
+from siteplan.svg_writer import svg_footer, svg_header, svg_line, svg_rect, svg_text
+
+SCALE = 10
+
+
+def main() -> None:
+    width = 45 * SCALE
+    height = 110.11 * SCALE
+    out = Path("output/siteplan_lot1.svg")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = []
+    lines.append(svg_header(width, height))
+    lines.append("  <!-- Lot 1 -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(0, 0, width, height), fill="none", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(width / 2, 20, "Lot 1", **{"text-anchor": "middle", "font-size": 14})
+    )
+
+    lines.append("")
+    lines.append("  <!-- Setback lines -->")
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, 180),
+            Point(width, 180),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append("  " + svg_text(5, 175, "Front setback 18'", **{"font-size": 12}))
+
+    rear_y = height - 110
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, rear_y),
+            Point(width, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, rear_y - 6, "Rear setback 11'", **{"font-size": 12})
+    )
+
+    lines.append(
+        "  "
+        + svg_line(
+            Point(80, 0),
+            Point(80, height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            85,
+            height / 2,
+            "Left setback 8'",
+            **{"font-size": 12},
+            transform=f"rotate(-90 85,{height / 2})",
+        )
+    )
+
+    right_x = width - 50
+    lines.append(
+        "  "
+        + svg_line(
+            Point(right_x, 0),
+            Point(right_x, height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            right_x - 5,
+            height / 2,
+            "Right setback 5'",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {right_x - 5},{height / 2})",
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Duplex -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(80, 180, 330, 280), fill="#dddddd", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(245, 320, "Duplex", **{"text-anchor": "middle", "font-size": 14})
+    )
+
+    lines.append("")
+    lines.append("  <!-- ADU -->")
+    adu_y = rear_y - 200
+    lines.append(
+        "  " + svg_rect(Rectangle(80, adu_y, 300, 200), fill="#cccccc", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            230,
+            adu_y + 100,
+            "ADU",
+            **{"text-anchor": "middle", "font-size": 14},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Parking Pads -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(80, 460, 90, 200), fill="#eeeeee", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(125, 560, "Parking 1", **{"text-anchor": "middle", "font-size": 12})
+    )
+    lines.append(
+        "  " + svg_rect(Rectangle(170, 460, 90, 200), fill="#eeeeee", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(215, 560, "Parking 2", **{"text-anchor": "middle", "font-size": 12})
+    )
+    lines.append(
+        "  " + svg_rect(Rectangle(260, 460, 90, 200), fill="#eeeeee", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(305, 560, "Parking 3", **{"text-anchor": "middle", "font-size": 12})
+    )
+
+    lines.append("")
+    lines.append("  <!-- Trash Pad -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(350, 460, 60, 200), fill="#eeeeee", stroke="black")
+    )
+    lines.append(
+        "  " + svg_text(380, 560, "Trash", **{"text-anchor": "middle", "font-size": 12})
+    )
+
+    lines.append(svg_footer())
+    out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/output/siteplan_lot1.svg
+++ b/output/siteplan_lot1.svg
@@ -1,0 +1,35 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='450' height='1101.1'>
+  <!-- Lot 1 -->
+  <rect x='0' y='0' width='450' height='1101.1' fill='none' stroke='black' />
+  <text x='225.0' y='20' text-anchor='middle' font-size='14'>Lot 1</text>
+
+  <!-- Setback lines -->
+  <line x1='0' y1='180' x2='450' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='175' font-size='12'>Front setback 18'</text>
+  <line x1='0' y1='991.0999999999999' x2='450' y2='991.0999999999999' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='985.0999999999999' font-size='12'>Rear setback 11'</text>
+  <line x1='80' y1='0' x2='80' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='85' y='550.55' font-size='12' transform='rotate(-90 85,550.55)'>Left setback 8'</text>
+  <line x1='400' y1='0' x2='400' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='395' y='550.55' font-size='12' transform='rotate(-90 395,550.55)'>Right setback 5'</text>
+
+  <!-- Duplex -->
+  <rect x='80' y='180' width='330' height='280' fill='#dddddd' stroke='black' />
+  <text x='245' y='320' text-anchor='middle' font-size='14'>Duplex</text>
+
+  <!-- ADU -->
+  <rect x='80' y='791.0999999999999' width='300' height='200' fill='#cccccc' stroke='black' />
+  <text x='230' y='891.0999999999999' text-anchor='middle' font-size='14'>ADU</text>
+
+  <!-- Parking Pads -->
+  <rect x='80' y='460' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='125' y='560' text-anchor='middle' font-size='12'>Parking 1</text>
+  <rect x='170' y='460' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='215' y='560' text-anchor='middle' font-size='12'>Parking 2</text>
+  <rect x='260' y='460' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='305' y='560' text-anchor='middle' font-size='12'>Parking 3</text>
+
+  <!-- Trash Pad -->
+  <rect x='350' y='460' width='60' height='200' fill='#eeeeee' stroke='black' />
+  <text x='380' y='560' text-anchor='middle' font-size='12'>Trash</text>
+</svg>

--- a/tests/test_example_siteplan_lot1.py
+++ b/tests/test_example_siteplan_lot1.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_siteplan_lot1(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = importlib.import_module("examples.siteplan_lot1")
+    module.main()
+    svg = Path("output/siteplan_lot1.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    assert "<rect" in content


### PR DESCRIPTION
## Summary
- add generator script for Lot 1 layout
- generate siteplan_lot1.svg using the new script
- test generator runs and creates SVG

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861eb842dec8330a7c49a31ef34d14e