### PR TITLE
Add SVG boundary and dimension tools

### DIFF
--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -1,11 +1,19 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import List
+from typing import List, Mapping, Optional
 from pathlib import Path
 
-from .geometry import Rectangle
-from .svg_writer import svg_footer, svg_grid, svg_header, svg_rect, svg_text
+from .geometry import Point, Rectangle
+from .svg_writer import (
+    svg_dimension_callout,
+    svg_footer,
+    svg_grid,
+    svg_header,
+    svg_property_boundary,
+    svg_rect,
+    svg_text,
+)
 
 
 @dataclass
@@ -15,8 +23,16 @@ class Layout:
     def add_shape(self, shape: Rectangle) -> None:
         self.shapes.append(shape)
 
-    def export_svg(self, path: Path, scale: float = 10) -> None:
-        """Export layout as scaled SVG with gridlines and basic dimensions."""
+    def export_svg(
+        self,
+        path: Path,
+        *,
+        scale: float = 10,
+        show_grid: bool = True,
+        arrow_size: float = 10,
+        text_style: Optional[Mapping[str, object]] = None,
+    ) -> None:
+        """Export layout as scaled SVG with gridlines and dimension callouts."""
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -28,20 +44,45 @@ class Layout:
 
         with path.open("w", encoding="utf-8") as f:
             f.write(svg_header(width, height) + "\n")
-            f.write(svg_grid(width, height) + "\n")
+            if show_grid:
+                f.write(svg_grid(width, height) + "\n")
+
+            boundary = Rectangle(0, 0, max_x, max_y)
+            f.write(svg_property_boundary(boundary) + "\n")
+
+            text_style = text_style or {"font-size": 12, "text-anchor": "middle"}
+
             for rect in self.shapes:
                 f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
-                label_x = rect.x + rect.width / 2
-                label_y = rect.y - 5
-                dims = f"{rect.width/scale}x{rect.height/scale} ft"
+
+                width_text = f"{rect.width/scale} ft"
+                start = Point(rect.x, rect.y - arrow_size * 2)
+                end = Point(rect.x + rect.width, rect.y - arrow_size * 2)
                 f.write(
-                    svg_text(
-                        label_x,
-                        label_y,
-                        dims,
-                        fill="black",
-                        **{"text-anchor": "middle", "font-size": 12},
+                    svg_dimension_callout(
+                        start,
+                        end,
+                        width_text,
+                        size=arrow_size,
+                        text_style=text_style,
+                        stroke="black",
                     )
                     + "\n"
                 )
+
+                height_text = f"{rect.height/scale} ft"
+                start_h = Point(rect.x - arrow_size * 2, rect.y)
+                end_h = Point(rect.x - arrow_size * 2, rect.y + rect.height)
+                f.write(
+                    svg_dimension_callout(
+                        start_h,
+                        end_h,
+                        height_text,
+                        size=arrow_size,
+                        text_style=text_style,
+                        stroke="black",
+                    )
+                    + "\n"
+                )
+
             f.write(svg_footer() + "\n")

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Iterable, Mapping
+from math import sqrt
+from typing import Iterable, Mapping, Optional
 
 from .geometry import Point, Rectangle
 
@@ -59,6 +60,62 @@ def svg_text(x: float, y: float, text: str, **attrs: object) -> str:
     text_attrs.update(attrs)
     attr_str = _attrs_to_str(text_attrs)
     return f"<text {attr_str}>{text}</text>"
+
+
+def svg_property_boundary(rect: Rectangle, **attrs: object) -> str:
+    """Draw a dashed rectangle to indicate the property boundary."""
+    boundary_attrs = {
+        "fill": "none",
+        "stroke": "black",
+        "stroke-dasharray": "4",
+    }
+    boundary_attrs.update(attrs)
+    return svg_rect(rect, **boundary_attrs)
+
+
+def _arrowhead(tip: Point, tail: Point, size: float) -> list[Point]:
+    """Calculate points for an arrow head polygon."""
+    dx = tail.x - tip.x
+    dy = tail.y - tip.y
+    length = sqrt(dx * dx + dy * dy) or 1
+    ux = dx / length
+    uy = dy / length
+    left = Point(
+        tip.x + ux * size - uy * (size / 2), tip.y + uy * size + ux * (size / 2)
+    )
+    right = Point(
+        tip.x + ux * size + uy * (size / 2), tip.y + uy * size - ux * (size / 2)
+    )
+    return [tip, left, right]
+
+
+def svg_arrow(p1: Point, p2: Point, size: float = 10, **attrs: object) -> str:
+    """Draw a line with an arrow head pointing to ``p2``."""
+    line = svg_line(p1, p2, **attrs)
+    head = svg_polygon(_arrowhead(p2, p1, size), **attrs)
+    return line + "\n" + head
+
+
+def svg_dimension_callout(
+    p1: Point,
+    p2: Point,
+    text: str,
+    *,
+    size: float = 10,
+    text_style: Optional[Mapping[str, object]] = None,
+    **attrs: object,
+) -> str:
+    """Draw a dimension line with arrowheads at both ends and a centered label."""
+    pieces = [svg_line(p1, p2, **attrs)]
+    pieces.append(svg_polygon(_arrowhead(p1, p2, size), **attrs))
+    pieces.append(svg_polygon(_arrowhead(p2, p1, size), **attrs))
+    mid_x = (p1.x + p2.x) / 2
+    mid_y = (p1.y + p2.y) / 2
+    text_attrs = {"fill": attrs.get("stroke", "black")}
+    if text_style:
+        text_attrs.update(text_style)
+    pieces.append(svg_text(mid_x, mid_y - size, text, **text_attrs))
+    return "\n".join(pieces)
 
 
 def svg_grid(width: float, height: float, spacing: float = 100) -> str:

--- a/tests/test_svg_style.py
+++ b/tests/test_svg_style.py
@@ -12,3 +12,5 @@ def test_svg_with_grid(tmp_path: Path):
     content = out_file.read_text()
     assert "<line" in content  # gridlines
     assert "<text" in content  # dimension label
+    assert "stroke-dasharray='4'" in content  # property boundary
+    assert "<polygon" in content  # arrow heads


### PR DESCRIPTION
## Summary
- add new utilities in svg_writer for drawing boundaries, arrows and callouts
- enhance Layout.export_svg with options for grid, text style and arrow size
- export property boundary and dimension callouts
- test style expectations for new SVG elements

## Testing
- `flake8 siteplan tests`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861e1d242ec8330908512aee983df9f