### PR TITLE
Add corrected site plan layout

### DIFF
--- a/Volumes/SSD/GITHUB/siteplan/output3
+++ b/Volumes/SSD/GITHUB/siteplan/output3
@@ -1,0 +1,36 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='450' height='1101.1'>
+  <!-- Lot 1 -->
+  <rect x='0' y='0' width='450' height='1101.1' fill='none' stroke='black' />
+  <text x='225.0' y='20' text-anchor='middle' font-size='14'>Lot 1</text>
+
+  <!-- Setback lines -->
+  <line x1='0' y1='180' x2='450' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='175' font-size='12'>Front setback 18'</text>
+  <line x1='0' y1='991.0999999999999' x2='450' y2='991.0999999999999' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='985.0999999999999' font-size='12'>Rear setback 11'</text>
+  <line x1='80' y1='0' x2='80' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='85' y='550.55' font-size='12' transform='rotate(-90 85,550.55)'>Left setback 8'</text>
+  <line x1='400' y1='0' x2='400' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='395' y='550.55' font-size='12' transform='rotate(-90 395,550.55)'>Right setback 5'</text>
+
+  <!-- Duplex -->
+  <rect x='80' y='180' width='330' height='280' fill='#dddddd' stroke='black' />
+  <text x='245.0' y='320.0' text-anchor='middle' font-size='14'>Duplex</text>
+
+  <!-- ADU -->
+  <rect x='80' y='660' width='300' height='200' fill='#cccccc' stroke='black' />
+  <text x='230.0' y='760.0' text-anchor='middle' font-size='14'>ADU</text>
+
+  <!-- Parking Pads -->
+  <rect x='80' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='125.0' y='960.0' text-anchor='middle' font-size='12'>Parking 1</text>
+  <rect x='170' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='215.0' y='960.0' text-anchor='middle' font-size='12'>Parking 2</text>
+  <rect x='260' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='305.0' y='960.0' text-anchor='middle' font-size='12'>Parking 3</text>
+
+  <!-- Trash Pad -->
+  <rect x='390' y='860' width='60' height='200' fill='#eeeeee' stroke='black' />
+  <text x='420.0' y='960.0' text-anchor='middle' font-size='12'>Trash</text>
+  <text x='445' y='1096.1' text-anchor='end' font-size='12'>Scale 1" = 10'</text>
+</svg>

--- a/examples/siteplan_lot1.py
+++ b/examples/siteplan_lot1.py
@@ -1,0 +1,246 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from siteplan.geometry import Point, Rectangle
+from siteplan.svg_writer import svg_footer, svg_header, svg_line, svg_rect, svg_text
+
+SCALE = 10
+
+
+def main() -> None:
+    width = 45 * SCALE
+    height = 110.11 * SCALE
+
+    front_y = 18 * SCALE
+    rear_y = height - 11 * SCALE
+    left_x = 8 * SCALE
+    right_x = width - 5 * SCALE
+
+    duplex_w = 33 * SCALE
+    duplex_h = 28 * SCALE
+    duplex_x = left_x
+    duplex_y = front_y
+
+    adu_w = 30 * SCALE
+    adu_h = 20 * SCALE
+    adu_x = left_x
+    adu_y = duplex_y + duplex_h + 20 * SCALE
+
+    parking_w = 9 * SCALE
+    parking_h = 20 * SCALE
+    parking_y = adu_y + adu_h
+
+    trash_w = 60
+    trash_h = parking_h
+    trash_x = width - trash_w
+    out = Path("output/siteplan_lot1.svg")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = []
+    lines.append(svg_header(width, height))
+    lines.append("  <!-- Lot 1 -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(0, 0, width, height), fill="none", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(width / 2, 20, "Lot 1", **{"text-anchor": "middle", "font-size": 14})
+    )
+
+    lines.append("")
+    lines.append("  <!-- Setback lines -->")
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, front_y),
+            Point(width, front_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, front_y - 5, "Front setback 18'", **{"font-size": 12})
+    )
+
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, rear_y),
+            Point(width, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, rear_y - 6, "Rear setback 11'", **{"font-size": 12})
+    )
+
+    lines.append(
+        "  "
+        + svg_line(
+            Point(left_x, 0),
+            Point(left_x, height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            left_x + 5,
+            height / 2,
+            "Left setback 8'",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {left_x + 5},{height / 2})",
+        )
+    )
+
+    lines.append(
+        "  "
+        + svg_line(
+            Point(right_x, 0),
+            Point(right_x, height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            right_x - 5,
+            height / 2,
+            "Right setback 5'",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {right_x - 5},{height / 2})",
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Duplex -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(duplex_x, duplex_y, duplex_w, duplex_h),
+            fill="#dddddd",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            duplex_x + duplex_w / 2,
+            duplex_y + duplex_h / 2,
+            "Duplex",
+            **{"text-anchor": "middle", "font-size": 14},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- ADU -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(adu_x, adu_y, adu_w, adu_h), fill="#cccccc", stroke="black"
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            adu_x + adu_w / 2,
+            adu_y + adu_h / 2,
+            "ADU",
+            **{"text-anchor": "middle", "font-size": 14},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Parking Pads -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(duplex_x, parking_y, parking_w, parking_h),
+            fill="#eeeeee",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            duplex_x + parking_w / 2,
+            parking_y + parking_h / 2,
+            "Parking 1",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(duplex_x + parking_w, parking_y, parking_w, parking_h),
+            fill="#eeeeee",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            duplex_x + parking_w * 1.5,
+            parking_y + parking_h / 2,
+            "Parking 2",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(duplex_x + parking_w * 2, parking_y, parking_w, parking_h),
+            fill="#eeeeee",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            duplex_x + parking_w * 2.5,
+            parking_y + parking_h / 2,
+            "Parking 3",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Trash Pad -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(trash_x, parking_y, trash_w, trash_h),
+            fill="#eeeeee",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            trash_x + trash_w / 2,
+            parking_y + trash_h / 2,
+            "Trash",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    lines.append(
+        "  "
+        + svg_text(
+            width - 5,
+            height - 5,
+            "Scale 1\" = 10'",
+            **{"text-anchor": "end", "font-size": 12},
+        )
+    )
+
+    lines.append(svg_footer())
+    out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/output/siteplan_lot1.svg
+++ b/output/siteplan_lot1.svg
@@ -1,0 +1,36 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='450' height='1101.1'>
+  <!-- Lot 1 -->
+  <rect x='0' y='0' width='450' height='1101.1' fill='none' stroke='black' />
+  <text x='225.0' y='20' text-anchor='middle' font-size='14'>Lot 1</text>
+
+  <!-- Setback lines -->
+  <line x1='0' y1='180' x2='450' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='175' font-size='12'>Front setback 18'</text>
+  <line x1='0' y1='991.0999999999999' x2='450' y2='991.0999999999999' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='985.0999999999999' font-size='12'>Rear setback 11'</text>
+  <line x1='80' y1='0' x2='80' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='85' y='550.55' font-size='12' transform='rotate(-90 85,550.55)'>Left setback 8'</text>
+  <line x1='400' y1='0' x2='400' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='395' y='550.55' font-size='12' transform='rotate(-90 395,550.55)'>Right setback 5'</text>
+
+  <!-- Duplex -->
+  <rect x='80' y='180' width='330' height='280' fill='#dddddd' stroke='black' />
+  <text x='245.0' y='320.0' text-anchor='middle' font-size='14'>Duplex</text>
+
+  <!-- ADU -->
+  <rect x='80' y='660' width='300' height='200' fill='#cccccc' stroke='black' />
+  <text x='230.0' y='760.0' text-anchor='middle' font-size='14'>ADU</text>
+
+  <!-- Parking Pads -->
+  <rect x='80' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='125.0' y='960.0' text-anchor='middle' font-size='12'>Parking 1</text>
+  <rect x='170' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='215.0' y='960.0' text-anchor='middle' font-size='12'>Parking 2</text>
+  <rect x='260' y='860' width='90' height='200' fill='#eeeeee' stroke='black' />
+  <text x='305.0' y='960.0' text-anchor='middle' font-size='12'>Parking 3</text>
+
+  <!-- Trash Pad -->
+  <rect x='390' y='860' width='60' height='200' fill='#eeeeee' stroke='black' />
+  <text x='420.0' y='960.0' text-anchor='middle' font-size='12'>Trash</text>
+  <text x='445' y='1096.1' text-anchor='end' font-size='12'>Scale 1" = 10'</text>
+</svg>

--- a/tests/test_example_siteplan_lot1.py
+++ b/tests/test_example_siteplan_lot1.py
@@ -1,0 +1,12 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_siteplan_lot1(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = importlib.import_module("examples.siteplan_lot1")
+    module.main()
+    svg = Path("output/siteplan_lot1.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    assert "<rect" in content


### PR DESCRIPTION
## Summary
- revise siteplan_lot1 generator with explicit dimension variables
- reposition ADU, parking pads and trash area
- add scale note
- regenerate siteplan SVG
- provide copy of the drawing at `Volumes/SSD/GITHUB/siteplan/output3`

## Testing
- `black --check .`
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861eb842dec8330a7c49a31ef34d14e