### PR TITLE
Add interactive CLI for shape checklist

### DIFF
--- a/siteplan/checklist_cli.py
+++ b/siteplan/checklist_cli.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from .geometry import Rectangle
+from .layout import Layout
+from .optimizer import apply_constraints, separate_shapes
+
+
+def main() -> None:
+    import argparse
+
+    parser = argparse.ArgumentParser(description="Interactive siteplan generator")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        default="output/siteplan.svg",
+        help="Output SVG file",
+    )
+    parser.add_argument(
+        "--font-size",
+        type=int,
+        default=12,
+        help="Font size for dimension labels",
+    )
+    args = parser.parse_args()
+
+    layout = Layout()
+    placements = []
+
+    prop_w_str = input("Property width in ft (blank for none): ").strip()
+    prop_h_str = input("Property height in ft (blank for none): ").strip()
+    prop_w = float(prop_w_str) * 10 if prop_w_str else None
+    prop_h = float(prop_h_str) * 10 if prop_h_str else None
+
+    num_shapes = int(input("How many shapes? "))
+    for i in range(num_shapes):
+        print(f"Shape {i + 1}")
+        width = float(input("  width (ft): ")) * 10
+        height = float(input("  height (ft): ")) * 10
+        x = float(input("  x position (ft): ")) * 10
+        y = float(input("  y position (ft): ")) * 10
+        orientation = input(
+            "  orientation [north|south|east|west] (default north): "
+        ).strip()
+        orientation = orientation or "north"
+        left = float(input("  left setback (ft, default 0): ") or 0) * 10
+        right = float(input("  right setback (ft, default 0): ") or 0) * 10
+        top = float(input("  top setback (ft, default 0): ") or 0) * 10
+        bottom = float(input("  bottom setback (ft, default 0): ") or 0) * 10
+
+        layout.add_shape(Rectangle(x, y, width, height))
+        placement = {
+            "setbacks": {
+                "left": left,
+                "right": right,
+                "top": top,
+                "bottom": bottom,
+            },
+            "facing": orientation,
+        }
+        if prop_w is not None:
+            placement["property_width"] = prop_w
+        if prop_h is not None:
+            placement["property_height"] = prop_h
+        placements.append(placement)
+
+    apply_constraints(layout, placements)
+    separate_shapes(layout)
+
+    layout.export_svg(Path(args.output), font_size=args.font_size)
+
+
+if __name__ == "__main__":
+    main()

--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -24,7 +24,7 @@ class Layout:
     def add_shape(self, shape: Rectangle) -> None:
         self.shapes.append(shape)
 
-    def export_svg(self, path: Path, scale: float = 10) -> None:
+    def export_svg(self, path: Path, scale: float = 10, font_size: int = 12) -> None:
         """Export layout as scaled SVG with gridlines and basic dimensions."""
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -41,7 +41,7 @@ class Layout:
             for rect in self.shapes:
                 f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
                 f.write(svg_boundary(rect) + "\n")
-                f.write(svg_dimensions(rect, scale) + "\n")
+                f.write(svg_dimensions(rect, scale, font_size) + "\n")
             f.write(svg_footer() + "\n")
 
     def save(self, path: Path) -> None:

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -74,7 +74,7 @@ def svg_boundary(rect: Rectangle, offset: float = 5, **attrs: object) -> str:
     return svg_polygon(points, **boundary_attrs)
 
 
-def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
+def svg_dimensions(rect: Rectangle, scale: float = 10, font_size: int = 12) -> str:
     """Return simple width/height dimension lines and labels for *rect*."""
     elements = []
     top_y = rect.y - 10
@@ -97,7 +97,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             top_y - 2,
             f"{rect.width/scale} ft",
             fill="black",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     elements.append(
@@ -107,7 +107,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             f"{rect.height/scale} ft",
             fill="black",
             transform=f"rotate(-90 {left_x - 2},{rect.y + rect.height / 2})",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     return "\n".join(elements)


### PR DESCRIPTION
## Summary
- allow custom label font-size in `svg_dimensions` and `Layout.export_svg`
- add `checklist_cli` module for interactive layout creation

## Testing
- `black siteplan tests examples -q`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f299709c8330bc167612d39d4fd3