### PR TITLE
Add pexpect tests and font-size option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 black
 flake8
 pytest
+pexpect

--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -24,8 +24,18 @@ class Layout:
     def add_shape(self, shape: Rectangle) -> None:
         self.shapes.append(shape)
 
-    def export_svg(self, path: Path, scale: float = 10) -> None:
-        """Export layout as scaled SVG with gridlines and basic dimensions."""
+    def export_svg(self, path: Path, scale: float = 10, font_size: int = 12) -> None:
+        """Export layout as scaled SVG with gridlines and basic dimensions.
+
+        Parameters
+        ----------
+        path:
+            Destination path for the SVG file.
+        scale:
+            Conversion factor from pixels to feet for dimension labels.
+        font_size:
+            Size of the text used for dimension annotations.
+        """
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
 
@@ -41,7 +51,7 @@ class Layout:
             for rect in self.shapes:
                 f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
                 f.write(svg_boundary(rect) + "\n")
-                f.write(svg_dimensions(rect, scale) + "\n")
+                f.write(svg_dimensions(rect, scale, font_size) + "\n")
             f.write(svg_footer() + "\n")
 
     def save(self, path: Path) -> None:

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -74,8 +74,18 @@ def svg_boundary(rect: Rectangle, offset: float = 5, **attrs: object) -> str:
     return svg_polygon(points, **boundary_attrs)
 
 
-def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
-    """Return simple width/height dimension lines and labels for *rect*."""
+def svg_dimensions(rect: Rectangle, scale: float = 10, font_size: int = 12) -> str:
+    """Return simple width/height dimension lines and labels for *rect*.
+
+    Parameters
+    ----------
+    rect:
+        Rectangle to annotate.
+    scale:
+        Scale factor for converting pixels to feet.
+    font_size:
+        Font size for dimension labels.
+    """
     elements = []
     top_y = rect.y - 10
     left_x = rect.x - 10
@@ -97,7 +107,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             top_y - 2,
             f"{rect.width/scale} ft",
             fill="black",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     elements.append(
@@ -107,7 +117,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             f"{rect.height/scale} ft",
             fill="black",
             transform=f"rotate(-90 {left_x - 2},{rect.y + rect.height / 2})",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     return "\n".join(elements)

--- a/tests/test_cli_interactive.py
+++ b/tests/test_cli_interactive.py
@@ -1,0 +1,19 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+pexpect = pytest.importorskip("pexpect")
+
+
+def test_cli_interactive(tmp_path: Path):
+    """Run the CLI inside a Python REPL using pexpect and verify output."""
+    child = pexpect.spawn(sys.executable, ["-i"], cwd=tmp_path, encoding="utf-8")
+    child.expect(">>>")
+    child.sendline("from siteplan.cli import main")
+    child.expect(">>>")
+    child.sendline("main('plan.svg')")
+    child.expect(">>>", timeout=10)
+    child.sendline("exit()")
+    child.expect(pexpect.EOF)
+    assert (tmp_path / "plan.svg").exists()

--- a/tests/test_font_size.py
+++ b/tests/test_font_size.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+
+from siteplan.geometry import Rectangle
+from siteplan.layout import Layout
+
+
+def test_export_svg_custom_font(tmp_path: Path):
+    layout = Layout()
+    layout.add_shape(Rectangle(0, 0, 10, 10))
+    out_file = tmp_path / "plan.svg"
+    layout.export_svg(out_file, font_size=20)
+    content = out_file.read_text()
+    assert "font-size='20'" in content


### PR DESCRIPTION
## Summary
- allow svg_dimensions() and Layout.export_svg() to accept `font_size`
- add `test_cli_interactive` using pexpect (skips if pexpect missing)
- add `test_export_svg_custom_font` to assert custom font-size
- include pexpect in requirements

## Testing
- `black .`
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f29ad3c0833088b06a04cf7df8a3