### PR TITLE
Add font size option to svg export

### DIFF
--- a/siteplan/layout.py
+++ b/siteplan/layout.py
@@ -24,7 +24,7 @@ class Layout:
     def add_shape(self, shape: Rectangle) -> None:
         self.shapes.append(shape)
 
-    def export_svg(self, path: Path, scale: float = 10) -> None:
+    def export_svg(self, path: Path, scale: float = 10, font_size: int = 12) -> None:
         """Export layout as scaled SVG with gridlines and basic dimensions."""
         path = Path(path)
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -41,7 +41,7 @@ class Layout:
             for rect in self.shapes:
                 f.write(svg_rect(rect, fill="none", stroke="black") + "\n")
                 f.write(svg_boundary(rect) + "\n")
-                f.write(svg_dimensions(rect, scale) + "\n")
+                f.write(svg_dimensions(rect, scale, font_size) + "\n")
             f.write(svg_footer() + "\n")
 
     def save(self, path: Path) -> None:

--- a/siteplan/svg_writer.py
+++ b/siteplan/svg_writer.py
@@ -74,8 +74,18 @@ def svg_boundary(rect: Rectangle, offset: float = 5, **attrs: object) -> str:
     return svg_polygon(points, **boundary_attrs)
 
 
-def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
-    """Return simple width/height dimension lines and labels for *rect*."""
+def svg_dimensions(rect: Rectangle, scale: float = 10, font_size: int = 12) -> str:
+    """Return simple width/height dimension lines and labels for *rect*.
+
+    Parameters
+    ----------
+    rect:
+        Rectangle to annotate with dimensions.
+    scale:
+        Drawing scale in pixels per foot.
+    font_size:
+        Font size for the dimension text labels.
+    """
     elements = []
     top_y = rect.y - 10
     left_x = rect.x - 10
@@ -97,7 +107,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             top_y - 2,
             f"{rect.width/scale} ft",
             fill="black",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     elements.append(
@@ -107,7 +117,7 @@ def svg_dimensions(rect: Rectangle, scale: float = 10) -> str:
             f"{rect.height/scale} ft",
             fill="black",
             transform=f"rotate(-90 {left_x - 2},{rect.y + rect.height / 2})",
-            **{"text-anchor": "middle", "font-size": 12},
+            **{"text-anchor": "middle", "font-size": font_size},
         )
     )
     return "\n".join(elements)


### PR DESCRIPTION
## Summary
- allow specifying font size when generating SVG dimension labels
- pass `font_size` through `Layout.export_svg`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f299ede883308755dd4b0f766803