### PR TITLE
Add dual lot setback lines

### DIFF
--- a/examples/siteplan_dual_lot.py
+++ b/examples/siteplan_dual_lot.py
@@ -1,0 +1,252 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from siteplan.geometry import Point, Rectangle
+from siteplan.svg_writer import svg_footer, svg_header, svg_line, svg_rect, svg_text
+
+SCALE = 10
+
+
+def main() -> None:
+    width = 917.6
+    height = 1102.2
+    center_x = 467.6
+    lot2_height = 1102.2
+    lot1_height = 1101.1
+
+    front_y = 18 * SCALE
+    rear_y = 991.2
+
+    lot2_left = 8 * SCALE
+    lot2_right = center_x - 5 * SCALE
+    lot1_left = center_x + 5 * SCALE
+    lot1_right = width - 5 * SCALE
+
+    out = Path("output/siteplan_dual_lot.svg")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = []
+    lines.append(svg_header(width, height))
+
+    # Lot 2 - left side
+    lines.append("  <!-- Lot 2 -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(0, 0, 467.6, 1102.2),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(467.6 / 2, 20, "Lot 2", **{"text-anchor": "middle", "font-size": 14})
+    )
+
+    # Lot 1 - right side
+    lines.append("  <!-- Lot 1 -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(center_x, 0, 450.0, 1101.1),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            center_x + 225.0,
+            20,
+            "Lot 1",
+            **{"text-anchor": "middle", "font-size": 14},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Setback lines -->")
+    # Lot 2 setbacks
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, front_y),
+            Point(center_x, front_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, front_y - 5, "18' Front Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, rear_y),
+            Point(center_x, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, rear_y - 6, "11' Rear Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot2_left, 0),
+            Point(lot2_left, lot2_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_left + 5,
+            lot2_height / 2,
+            "8' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot2_left + 5},{lot2_height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot2_right, 0),
+            Point(lot2_right, lot2_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_right - 5,
+            lot2_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot2_right - 5},{lot2_height / 2})",
+        )
+    )
+
+    # Lot 1 setbacks
+    lines.append(
+        "  "
+        + svg_line(
+            Point(center_x, front_y),
+            Point(width, front_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(center_x + 5, front_y - 5, "18' Front Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(center_x, rear_y),
+            Point(width, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(center_x + 5, rear_y - 6, "11' Rear Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot1_left, 0),
+            Point(lot1_left, lot1_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_left + 5,
+            lot1_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot1_left + 5},{lot1_height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot1_right, 0),
+            Point(lot1_right, lot1_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_right - 5,
+            lot1_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot1_right - 5},{lot1_height / 2})",
+        )
+    )
+
+    # Center divider
+    lines.append("  <!-- Divider -->")
+    lines.append(
+        "  " + svg_line(Point(center_x, 0), Point(center_x, height), stroke="black")
+    )
+
+    # Street labels
+    lines.append(
+        "  "
+        + svg_text(
+            width / 2,
+            15,
+            "22nd Avenue South (Front)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            10,
+            height / 2,
+            "30th Street South",
+            **{"text-anchor": "middle", "font-size": 12},
+            transform=f"rotate(-90 10,{height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width / 2,
+            height - 5,
+            "16' Alley (Rear)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    lines.append(
+        "  "
+        + svg_text(
+            width - 5,
+            height - 5,
+            "Scale 1\" = 10'",
+            **{"text-anchor": "end", "font-size": 12},
+        )
+    )
+
+    lines.append(svg_footer())
+    out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/output/siteplan_dual_lot.svg
+++ b/output/siteplan_dual_lot.svg
@@ -1,0 +1,32 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='917.6' height='1102.2'>
+  <!-- Lot 2 -->
+  <rect x='0' y='0' width='467.6' height='1102.2' fill='none' stroke='black' stroke-width='2' />
+  <text x='233.8' y='20' text-anchor='middle' font-size='14'>Lot 2</text>
+  <!-- Lot 1 -->
+  <rect x='467.6' y='0' width='450.0' height='1101.1' fill='none' stroke='black' stroke-width='2' />
+  <text x='692.6' y='20' text-anchor='middle' font-size='14'>Lot 1</text>
+
+  <!-- Setback lines -->
+  <line x1='0' y1='180' x2='467.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='175' font-size='12'>18' Front Setback</text>
+  <line x1='0' y1='991.2' x2='467.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='985.2' font-size='12'>11' Rear Setback</text>
+  <line x1='80' y1='0' x2='80' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='85' y='551.1' font-size='12' transform='rotate(-90 85,551.1)'>8' Side Setback</text>
+  <line x1='417.6' y1='0' x2='417.6' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='412.6' y='551.1' font-size='12' transform='rotate(-90 412.6,551.1)'>5' Side Setback</text>
+  <line x1='467.6' y1='180' x2='917.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='472.6' y='175' font-size='12'>18' Front Setback</text>
+  <line x1='467.6' y1='991.2' x2='917.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='472.6' y='985.2' font-size='12'>11' Rear Setback</text>
+  <line x1='517.6' y1='0' x2='517.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='522.6' y='550.55' font-size='12' transform='rotate(-90 522.6,550.55)'>5' Side Setback</text>
+  <line x1='867.6' y1='0' x2='867.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='862.6' y='550.55' font-size='12' transform='rotate(-90 862.6,550.55)'>5' Side Setback</text>
+  <!-- Divider -->
+  <line x1='467.6' y1='0' x2='467.6' y2='1102.2' stroke='black' />
+  <text x='458.8' y='15' text-anchor='middle' font-size='12'>22nd Avenue South (Front)</text>
+  <text x='10' y='551.1' text-anchor='middle' font-size='12' transform='rotate(-90 10,551.1)'>30th Street South</text>
+  <text x='458.8' y='1097.2' text-anchor='middle' font-size='12'>16' Alley (Rear)</text>
+  <text x='912.6' y='1097.2' text-anchor='end' font-size='12'>Scale 1" = 10'</text>
+</svg>

--- a/tests/test_example_siteplan_dual_lot.py
+++ b/tests/test_example_siteplan_dual_lot.py
@@ -1,0 +1,13 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_siteplan_dual_lot(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = importlib.import_module("examples.siteplan_dual_lot")
+    module.main()
+    svg = Path("output/siteplan_dual_lot.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    assert "<rect" in content
+    assert "Front Setback" in content


### PR DESCRIPTION
## Summary
- update `siteplan_dual_lot.py` to draw front, rear, and side setback lines for each lot
- regenerate `siteplan_dual_lot.svg`
- check for setback label in regression test

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f7ee795483308894d587c7f788ae