### PR TITLE
Fix title text encoding

### DIFF
--- a/examples/siteplan_dual_lot.py
+++ b/examples/siteplan_dual_lot.py
@@ -1,0 +1,628 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from siteplan.geometry import Point, Rectangle
+from datetime import date
+
+from siteplan.svg_writer import (
+    svg_boundary,
+    svg_footer,
+    svg_header,
+    svg_line,
+    svg_polygon,
+    svg_rect,
+    svg_text,
+)
+
+SCALE = 10
+
+
+def main() -> None:
+    width = 917.6
+    height = 1102.2
+    center_x = 467.6
+    lot2_height = 1102.2
+    lot1_height = 1101.1
+
+    front_y = 18 * SCALE
+    rear_y = 991.2
+
+    lot2_left = 8 * SCALE
+    lot2_right = center_x - 5 * SCALE
+    lot1_left = center_x + 5 * SCALE
+    lot1_right = width - 5 * SCALE
+
+    out = Path("output/siteplan_dual_lot.svg")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = []
+    lines.append(svg_header(width, height))
+
+    # Title block
+    today = date.today().isoformat()
+    # place the title block in the top-left corner
+    title_y = 5
+    lines.append("  <!-- Title Block -->")
+    lines.append(
+        "  " + svg_rect(Rectangle(5, title_y, 300, 50), fill="#f5f5f5", stroke="black")
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            10,
+            title_y + 20,
+            "Site Plan \u2013 Lot 1 &amp; Lot 2 (NTM-1 St Pete)",
+            **{"font-size": 14, "font-family": "sans-serif"},
+        )
+    )
+
+    # North arrow
+    lines.append("  <!-- North Arrow -->")
+    arrow_top = 40
+    lines.append(
+        "  "
+        + svg_polygon(
+            [
+                Point(width / 2, arrow_top),
+                Point(width / 2 - 10, arrow_top + 20),
+                Point(width / 2 + 10, arrow_top + 20),
+            ],
+            fill="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width / 2,
+            arrow_top + 35,
+            "North",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            10,
+            title_y + 40,
+            f"Prepared: {today}",
+            **{"font-size": 12, "font-family": "sans-serif"},
+        )
+    )
+
+    # Lot 2 - left side
+    lines.append("  <!-- Lot 2 -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(0, 0, 467.6, 1102.2),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(467.6 / 2, 20, "Lot 2", **{"text-anchor": "middle", "font-size": 14})
+    )
+
+    # Lot 1 - right side
+    lines.append("  <!-- Lot 1 -->")
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(center_x, 0, 450.0, 1101.1),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            center_x + 225.0,
+            20,
+            "Lot 1",
+            **{"text-anchor": "middle", "font-size": 14},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Setback lines -->")
+    # Lot 2 setbacks
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, front_y),
+            Point(center_x, front_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, front_y - 5, "18' Front Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(0, rear_y),
+            Point(center_x, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  " + svg_text(5, rear_y - 6, "11' Rear Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot2_left, 0),
+            Point(lot2_left, lot2_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_left + 5,
+            lot2_height / 2,
+            "8' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot2_left + 5},{lot2_height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot2_right, 0),
+            Point(lot2_right, lot2_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_right - 5,
+            lot2_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot2_right - 5},{lot2_height / 2})",
+        )
+    )
+
+    # Lot 1 setbacks
+    lines.append(
+        "  "
+        + svg_line(
+            Point(center_x, front_y),
+            Point(width, front_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(center_x + 5, front_y - 5, "18' Front Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(center_x, rear_y),
+            Point(width, rear_y),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(center_x + 5, rear_y - 6, "11' Rear Setback", **{"font-size": 12})
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot1_left, 0),
+            Point(lot1_left, lot1_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_left + 5,
+            lot1_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot1_left + 5},{lot1_height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_line(
+            Point(lot1_right, 0),
+            Point(lot1_right, lot1_height),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_right - 5,
+            lot1_height / 2,
+            "5' Side Setback",
+            **{"font-size": 12},
+            transform=f"rotate(-90 {lot1_right - 5},{lot1_height / 2})",
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Buildable Areas -->")
+    buildable2 = Rectangle(lot2_left, front_y, lot2_right - lot2_left, rear_y - front_y)
+    buildable1 = Rectangle(lot1_left, front_y, lot1_right - lot1_left, rear_y - front_y)
+    lines.append(
+        "  "
+        + svg_boundary(
+            buildable2, offset=0, stroke="gray", **{"stroke-dasharray": "4 4"}
+        )
+    )
+    lines.append(
+        "  "
+        + svg_boundary(
+            buildable1, offset=0, stroke="gray", **{"stroke-dasharray": "4 4"}
+        )
+    )
+
+    # Center divider
+    lines.append("  <!-- Divider -->")
+    lines.append(
+        "  " + svg_line(Point(center_x, 0), Point(center_x, height), stroke="black")
+    )
+
+    # Street labels
+    lines.append(
+        "  "
+        + svg_text(
+            width / 2,
+            15,
+            "22nd Avenue South (Front)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            10,
+            height / 2,
+            "30th Street South",
+            **{"text-anchor": "middle", "font-size": 12},
+            transform=f"rotate(-90 10,{height / 2})",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width / 2,
+            height - 5,
+            "16' Alley (Rear)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    scale_bar_y = height - 40
+    lines.append(
+        "  "
+        + svg_line(
+            Point(width - 160, scale_bar_y),
+            Point(width - 60, scale_bar_y),
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width - 110,
+            scale_bar_y - 5,
+            "10'",
+            **{"text-anchor": "middle", "font-size": 10},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width - 5,
+            scale_bar_y - 15,
+            "Scale 1\" = 10'",
+            **{"text-anchor": "end", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            width - 5,
+            scale_bar_y + 15,
+            "Zoning: NTM-1 (St. Petersburg, FL) \u2013 Setback Compliant",
+            **{"text-anchor": "end", "font-size": 12},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Duplexes -->")
+    duplex_w = 33 * SCALE
+    duplex_h = 28 * SCALE
+    lot2_duplex_x = 87.8
+    lot1_duplex_x = 517.6
+    duplex_y = front_y
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot2_duplex_x, duplex_y, duplex_w, duplex_h),
+            fill="#ddddff",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_duplex_x + duplex_w / 2,
+            duplex_y + duplex_h / 2,
+            "Front Duplex (33' × 28', 2-Story)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot1_duplex_x, duplex_y, duplex_w, duplex_h),
+            fill="#ddddff",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_duplex_x + duplex_w / 2,
+            duplex_y + duplex_h / 2,
+            "Front Duplex (33' × 28', 2-Story)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    # Side door for Lot 2 left unit facing 30th Street South
+    door_x = lot2_duplex_x
+    door_y = 300
+    lines.append("  " + svg_rect(Rectangle(door_x, door_y, 5, 10), fill="black"))
+    lines.append(
+        "  "
+        + svg_text(
+            door_x - 5,
+            door_y + 5,
+            "Side Door (Facing 30th St S)",
+            **{
+                "font-size": 10,
+                "text-anchor": "end",
+                "transform": f"rotate(-90 {door_x - 5},{door_y + 5})",
+            },
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- Porches -->")
+    porch_w = 6 * SCALE
+    porch_h = 10 * SCALE
+    porch_y = 120
+    lot2_porches = [(67.8, "Porch A (6' × 10')"), (237.8, "Porch B (6' × 10')")]
+    lot1_porches = [(502.6, "Porch A (6' × 10')"), (672.6, "Porch B (6' × 10')")]
+
+    for x, label in lot2_porches:
+        lines.append(
+            "  "
+            + svg_rect(
+                Rectangle(x, porch_y, porch_w, porch_h),
+                fill="#ffeedd",
+                stroke="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_text(
+                x + porch_w / 2,
+                porch_y + porch_h / 2,
+                label,
+                **{"text-anchor": "middle", "font-size": 10},
+            )
+        )
+
+    for x, label in lot1_porches:
+        lines.append(
+            "  "
+            + svg_rect(
+                Rectangle(x, porch_y, porch_w, porch_h),
+                fill="#ffeedd",
+                stroke="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_text(
+                x + porch_w / 2,
+                porch_y + porch_h / 2,
+                label,
+                **{"text-anchor": "middle", "font-size": 10},
+            )
+        )
+
+    lines.append("")
+    lines.append("  <!-- Garages with ADUs -->")
+    adu_w = 30 * SCALE
+    adu_h = 20 * SCALE
+    adu_y = duplex_y + duplex_h + 20 * SCALE
+    lot2_adu_x = 93.8
+    lot1_adu_x = 518.8
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot2_adu_x, adu_y, adu_w, adu_h),
+            fill="#ccffcc",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_adu_x + adu_w / 2,
+            adu_y + adu_h / 2,
+            "Garage with ADU (2BR/1BA)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot1_adu_x, adu_y, adu_w, adu_h),
+            fill="#ccffcc",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_adu_x + adu_w / 2,
+            adu_y + adu_h / 2,
+            "Garage with ADU (2BR/1BA)",
+            **{"text-anchor": "middle", "font-size": 12},
+        )
+    )
+
+    lines.append("")
+    lines.append("  <!-- ADU Stairs -->")
+    for adu_x in [lot2_adu_x, lot1_adu_x]:
+        base_x = adu_x + adu_w / 2
+        base_y = adu_y + adu_h
+        lines.append(
+            "  "
+            + svg_line(
+                Point(base_x, base_y),
+                Point(base_x, base_y + 20),
+                stroke="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_polygon(
+                [
+                    Point(base_x - 5, base_y + 20),
+                    Point(base_x + 5, base_y + 20),
+                    Point(base_x, base_y + 30),
+                ],
+                fill="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_text(
+                base_x,
+                base_y + 35,
+                "Stairs",
+                **{"text-anchor": "middle", "font-size": 10},
+            )
+        )
+
+    lines.append("")
+    lines.append("  <!-- Parking Pads -->")
+    pad_w = 9 * SCALE
+    pad_h = 20 * SCALE
+    pad_y = adu_y + adu_h
+    lot2_pads = [93.8, 193.8, 293.8]
+    lot1_pads = [518.8, 618.8, 718.8]
+
+    for idx, x in enumerate(lot2_pads, 1):
+        lines.append(
+            "  "
+            + svg_rect(
+                Rectangle(x, pad_y, pad_w, pad_h),
+                fill="#ffff99",
+                stroke="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_text(
+                x + pad_w / 2,
+                pad_y + pad_h / 2,
+                f"P{idx}",
+                **{"text-anchor": "middle", "font-size": 10},
+            )
+        )
+
+    for idx, x in enumerate(lot1_pads, 1):
+        lines.append(
+            "  "
+            + svg_rect(
+                Rectangle(x, pad_y, pad_w, pad_h),
+                fill="#ffff99",
+                stroke="black",
+            )
+        )
+        lines.append(
+            "  "
+            + svg_text(
+                x + pad_w / 2,
+                pad_y + pad_h / 2,
+                f"P{idx}",
+                **{"text-anchor": "middle", "font-size": 10},
+            )
+        )
+
+    lines.append("")
+    lines.append("  <!-- Trash Pads -->")
+    trash_w = 6 * SCALE
+    trash_h = 20 * SCALE
+    trash_y = pad_y
+    lot2_trash_x = 390
+    lot1_trash_x = 880
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot2_trash_x, trash_y, trash_w, trash_h),
+            fill="#deb887",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot2_trash_x + trash_w / 2,
+            trash_y + trash_h / 2,
+            "Trash Pad (6' × 20')",
+            **{"text-anchor": "middle", "font-size": 10},
+        )
+    )
+    lines.append(
+        "  "
+        + svg_rect(
+            Rectangle(lot1_trash_x, trash_y, trash_w, trash_h),
+            fill="#deb887",
+            stroke="black",
+        )
+    )
+    lines.append(
+        "  "
+        + svg_text(
+            lot1_trash_x + trash_w / 2,
+            trash_y + trash_h / 2,
+            "Trash Pad (6' × 20')",
+            **{"text-anchor": "middle", "font-size": 10},
+        )
+    )
+
+    lines.append(svg_footer())
+    out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/output/siteplan_dual_lot.svg
+++ b/output/siteplan_dual_lot.svg
@@ -1,0 +1,98 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='917.6' height='1102.2'>
+  <!-- Title Block -->
+  <rect x='5' y='5' width='300' height='50' fill='#f5f5f5' stroke='black' />
+  <text x='10' y='25' font-size='14' font-family='sans-serif'>Site Plan – Lot 1 &amp; Lot 2 (NTM-1 St Pete)</text>
+  <!-- North Arrow -->
+  <polygon points='458.8,40 448.8,60 468.8,60' fill='black' />
+  <text x='458.8' y='75' text-anchor='middle' font-size='12'>North</text>
+  <text x='10' y='45' font-size='12' font-family='sans-serif'>Prepared: 2025-06-30</text>
+  <!-- Lot 2 -->
+  <rect x='0' y='0' width='467.6' height='1102.2' fill='none' stroke='black' stroke-width='2' />
+  <text x='233.8' y='20' text-anchor='middle' font-size='14'>Lot 2</text>
+  <!-- Lot 1 -->
+  <rect x='467.6' y='0' width='450.0' height='1101.1' fill='none' stroke='black' stroke-width='2' />
+  <text x='692.6' y='20' text-anchor='middle' font-size='14'>Lot 1</text>
+
+  <!-- Setback lines -->
+  <line x1='0' y1='180' x2='467.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='175' font-size='12'>18' Front Setback</text>
+  <line x1='0' y1='991.2' x2='467.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='5' y='985.2' font-size='12'>11' Rear Setback</text>
+  <line x1='80' y1='0' x2='80' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='85' y='551.1' font-size='12' transform='rotate(-90 85,551.1)'>8' Side Setback</text>
+  <line x1='417.6' y1='0' x2='417.6' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='412.6' y='551.1' font-size='12' transform='rotate(-90 412.6,551.1)'>5' Side Setback</text>
+  <line x1='467.6' y1='180' x2='917.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+  <text x='472.6' y='175' font-size='12'>18' Front Setback</text>
+  <line x1='467.6' y1='991.2' x2='917.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+  <text x='472.6' y='985.2' font-size='12'>11' Rear Setback</text>
+  <line x1='517.6' y1='0' x2='517.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='522.6' y='550.55' font-size='12' transform='rotate(-90 522.6,550.55)'>5' Side Setback</text>
+  <line x1='867.6' y1='0' x2='867.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+  <text x='862.6' y='550.55' font-size='12' transform='rotate(-90 862.6,550.55)'>5' Side Setback</text>
+
+  <!-- Buildable Areas -->
+  <polygon points='80,180 417.6,180 417.6,991.2 80,991.2' fill='none' stroke='gray' stroke-dasharray='4 4' />
+  <polygon points='517.6,180 867.6,180 867.6,991.2 517.6,991.2' fill='none' stroke='gray' stroke-dasharray='4 4' />
+  <!-- Divider -->
+  <line x1='467.6' y1='0' x2='467.6' y2='1102.2' stroke='black' />
+  <text x='458.8' y='15' text-anchor='middle' font-size='12'>22nd Avenue South (Front)</text>
+  <text x='10' y='551.1' text-anchor='middle' font-size='12' transform='rotate(-90 10,551.1)'>30th Street South</text>
+  <text x='458.8' y='1097.2' text-anchor='middle' font-size='12'>16' Alley (Rear)</text>
+  <line x1='757.6' y1='1062.2' x2='857.6' y2='1062.2' stroke='black' stroke-width='2' />
+  <text x='807.6' y='1057.2' text-anchor='middle' font-size='10'>10'</text>
+  <text x='912.6' y='1047.2' text-anchor='end' font-size='12'>Scale 1" = 10'</text>
+  <text x='912.6' y='1077.2' text-anchor='end' font-size='12'>Zoning: NTM-1 (St. Petersburg, FL) – Setback Compliant</text>
+
+  <!-- Duplexes -->
+  <rect x='87.8' y='180' width='330' height='280' fill='#ddddff' stroke='black' />
+  <text x='252.8' y='320.0' text-anchor='middle' font-size='12'>Front Duplex (33' × 28', 2-Story)</text>
+  <rect x='517.6' y='180' width='330' height='280' fill='#ddddff' stroke='black' />
+  <text x='682.6' y='320.0' text-anchor='middle' font-size='12'>Front Duplex (33' × 28', 2-Story)</text>
+  <rect x='87.8' y='300' width='5' height='10' fill='black' />
+  <text x='82.8' y='305' font-size='10' text-anchor='end' transform='rotate(-90 82.8,305)'>Side Door (Facing 30th St S)</text>
+
+  <!-- Porches -->
+  <rect x='67.8' y='120' width='60' height='100' fill='#ffeedd' stroke='black' />
+  <text x='97.8' y='170.0' text-anchor='middle' font-size='10'>Porch A (6' × 10')</text>
+  <rect x='237.8' y='120' width='60' height='100' fill='#ffeedd' stroke='black' />
+  <text x='267.8' y='170.0' text-anchor='middle' font-size='10'>Porch B (6' × 10')</text>
+  <rect x='502.6' y='120' width='60' height='100' fill='#ffeedd' stroke='black' />
+  <text x='532.6' y='170.0' text-anchor='middle' font-size='10'>Porch A (6' × 10')</text>
+  <rect x='672.6' y='120' width='60' height='100' fill='#ffeedd' stroke='black' />
+  <text x='702.6' y='170.0' text-anchor='middle' font-size='10'>Porch B (6' × 10')</text>
+
+  <!-- Garages with ADUs -->
+  <rect x='93.8' y='660' width='300' height='200' fill='#ccffcc' stroke='black' />
+  <text x='243.8' y='760.0' text-anchor='middle' font-size='12'>Garage with ADU (2BR/1BA)</text>
+  <rect x='518.8' y='660' width='300' height='200' fill='#ccffcc' stroke='black' />
+  <text x='668.8' y='760.0' text-anchor='middle' font-size='12'>Garage with ADU (2BR/1BA)</text>
+
+  <!-- ADU Stairs -->
+  <line x1='243.8' y1='860' x2='243.8' y2='880' stroke='black' />
+  <polygon points='238.8,880 248.8,880 243.8,890' fill='black' />
+  <text x='243.8' y='895' text-anchor='middle' font-size='10'>Stairs</text>
+  <line x1='668.8' y1='860' x2='668.8' y2='880' stroke='black' />
+  <polygon points='663.8,880 673.8,880 668.8,890' fill='black' />
+  <text x='668.8' y='895' text-anchor='middle' font-size='10'>Stairs</text>
+
+  <!-- Parking Pads -->
+  <rect x='93.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='138.8' y='960.0' text-anchor='middle' font-size='10'>P1</text>
+  <rect x='193.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='238.8' y='960.0' text-anchor='middle' font-size='10'>P2</text>
+  <rect x='293.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='338.8' y='960.0' text-anchor='middle' font-size='10'>P3</text>
+  <rect x='518.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='563.8' y='960.0' text-anchor='middle' font-size='10'>P1</text>
+  <rect x='618.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='663.8' y='960.0' text-anchor='middle' font-size='10'>P2</text>
+  <rect x='718.8' y='860' width='90' height='200' fill='#ffff99' stroke='black' />
+  <text x='763.8' y='960.0' text-anchor='middle' font-size='10'>P3</text>
+
+  <!-- Trash Pads -->
+  <rect x='390' y='860' width='60' height='200' fill='#deb887' stroke='black' />
+  <text x='420.0' y='960.0' text-anchor='middle' font-size='10'>Trash Pad (6' × 20')</text>
+  <rect x='880' y='860' width='60' height='200' fill='#deb887' stroke='black' />
+  <text x='910.0' y='960.0' text-anchor='middle' font-size='10'>Trash Pad (6' × 20')</text>
+</svg>

--- a/tests/test_example_siteplan_dual_lot.py
+++ b/tests/test_example_siteplan_dual_lot.py
@@ -1,0 +1,21 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_siteplan_dual_lot(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = importlib.import_module("examples.siteplan_dual_lot")
+    module.main()
+    svg = Path("output/siteplan_dual_lot.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    assert "<rect" in content
+    assert "Front Setback" in content
+    assert "Front Duplex" in content
+    assert "Porch A" in content
+    assert "Side Door" in content
+    assert "Garage with ADU" in content
+    assert "P1" in content
+    assert "Trash Pad" in content
+    assert "North" in content
+    assert "Zoning: NTM-1" in content


### PR DESCRIPTION
## Summary
- escape ampersand in site plan title to keep SVG valid
- regenerate `siteplan_dual_lot.svg`

## Testing
- `flake8`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6861f7ee795483308894d587c7f788ae