### PR TITLE
Add ADU stairs and lot dimension labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,3 +91,13 @@ python examples/duplex_adu.py
 ```
 
 The resulting SVG will be written to `output/examples/duplex_adu.svg`.
+
+## Viewing Example Output
+
+GitHub's diff viewer does not always render new SVG files in pull requests.
+To preview the generated site plans, open the SVG file directly in the
+repository and click **View raw**. For example, after running the dual lot
+example the file will be written to `output/siteplan_dual_lot.svg`. Opening this
+file in your browser (or embedding it in Markdown using
+`![Site Plan](output/siteplan_dual_lot.svg?sanitize=true)`) will display the full
+drawing.

--- a/examples/siteplan_dual_lot.py
+++ b/examples/siteplan_dual_lot.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from siteplan.geometry import Point, Rectangle
+from siteplan.svg_writer import (
+    svg_footer,
+    svg_header,
+    svg_line,
+    svg_polygon,
+    svg_rect,
+    svg_text,
+)
+
+SCALE = 10
+
+
+def dim_horizontal(x1: float, x2: float, y: float, text: str) -> str:
+    """Return SVG elements for a horizontal dimension line with arrows."""
+    elements: list[str] = []
+    elements.append(
+        svg_line(
+            Point(x1, y),
+            Point(x2, y),
+            stroke="black",
+            **{"stroke-dasharray": "4,2"},
+        )
+    )
+    arrow = 5
+    elements.append(
+        svg_polygon(
+            [Point(x1, y - arrow), Point(x1, y + arrow), Point(x1 - arrow, y)],
+            fill="black",
+        )
+    )
+    elements.append(
+        svg_polygon(
+            [Point(x2, y - arrow), Point(x2, y + arrow), Point(x2 + arrow, y)],
+            fill="black",
+        )
+    )
+    elements.append(
+        svg_text(
+            (x1 + x2) / 2,
+            y - 6,
+            text,
+            fill="black",
+            **{"font-size": 10, "font-family": "sans-serif", "text-anchor": "middle"},
+        )
+    )
+    return "\n".join(elements)
+
+
+def dim_vertical(x: float, y1: float, y2: float, text: str) -> str:
+    """Return SVG elements for a vertical dimension line with arrows."""
+    elements: list[str] = []
+    elements.append(
+        svg_line(
+            Point(x, y1),
+            Point(x, y2),
+            stroke="black",
+            **{"stroke-dasharray": "4,2"},
+        )
+    )
+    arrow = 5
+    elements.append(
+        svg_polygon(
+            [Point(x - arrow, y1), Point(x + arrow, y1), Point(x, y1 - arrow)],
+            fill="black",
+        )
+    )
+    elements.append(
+        svg_polygon(
+            [Point(x - arrow, y2), Point(x + arrow, y2), Point(x, y2 + arrow)],
+            fill="black",
+        )
+    )
+    elements.append(
+        svg_text(
+            x + 6,
+            (y1 + y2) / 2,
+            text,
+            fill="black",
+            transform=f"rotate(-90 {x + 6},{(y1 + y2) / 2})",
+            **{"font-size": 10, "font-family": "sans-serif", "text-anchor": "middle"},
+        )
+    )
+    return "\n".join(elements)
+
+
+def main() -> None:
+    width = 917.6
+    height = 1102.2
+    center_x = 467.6
+
+    front_y = 18 * SCALE
+    rear_y = 991.2
+
+    lot2_left = 8 * SCALE
+    lot2_right = center_x - 5 * SCALE
+    lot1_left = center_x + 5 * SCALE
+    lot1_right = width - 5 * SCALE
+
+    out = Path("output/siteplan_dual_lot.svg")
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    lines: list[str] = []
+    lines.append(svg_header(width, height))
+
+    # Lot rectangles
+    lines.append(
+        svg_rect(
+            Rectangle(0, 0, 467.6, 1102.2),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(center_x, 0, 450.0, 1101.1),
+            fill="none",
+            stroke="black",
+            **{"stroke-width": 2},
+        )
+    )
+
+    # Center divider
+    lines.append(svg_line(Point(center_x, 0), Point(center_x, height), stroke="black"))
+
+    # Setback lines
+    for x1, x2 in ((0, center_x), (center_x, width)):
+        lines.append(
+            svg_line(
+                Point(x1, front_y),
+                Point(x2, front_y),
+                stroke="blue",
+                **{"stroke-dasharray": "5,5"},
+            )
+        )
+        lines.append(
+            svg_line(
+                Point(x1, rear_y),
+                Point(x2, rear_y),
+                stroke="blue",
+                **{"stroke-dasharray": "5,5"},
+            )
+        )
+
+    lines.append(
+        svg_line(
+            Point(lot2_left, 0),
+            Point(lot2_left, 1102.2),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        svg_line(
+            Point(lot2_right, 0),
+            Point(lot2_right, 1102.2),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        svg_line(
+            Point(lot1_left, 0),
+            Point(lot1_left, 1101.1),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+    lines.append(
+        svg_line(
+            Point(lot1_right, 0),
+            Point(lot1_right, 1101.1),
+            stroke="blue",
+            **{"stroke-dasharray": "5,5"},
+        )
+    )
+
+    # Duplexes
+    duplex_w = 33 * SCALE
+    duplex_h = 28 * SCALE
+    lines.append(
+        svg_rect(
+            Rectangle(87.8, front_y, duplex_w, duplex_h), fill="blue", stroke="black"
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(517.6, front_y, duplex_w, duplex_h), fill="blue", stroke="black"
+        )
+    )
+
+    # Porches
+    porch_w = 6 * SCALE
+    porch_h = 10 * SCALE
+    porch_y = 120
+    for x in (67.8, 237.8, 502.6, 672.6):
+        lines.append(
+            svg_rect(
+                Rectangle(x, porch_y, porch_w, porch_h), fill="blue", stroke="black"
+            )
+        )
+
+    # Garages with ADUs
+    adu_w = 30 * SCALE
+    adu_h = 20 * SCALE
+    adu_y = 660
+    lines.append(
+        svg_rect(Rectangle(93.8, adu_y, adu_w, adu_h), fill="green", stroke="black")
+    )
+    lines.append(
+        svg_rect(Rectangle(518.8, adu_y, adu_w, adu_h), fill="green", stroke="black")
+    )
+
+    # A/C units and stairs
+    ac_size = 30
+    stair_w = 30
+    stair_d = 60
+    lines.append(
+        svg_rect(
+            Rectangle(393.8, adu_y, stair_w, stair_d),
+            fill="#999999",
+            stroke="black",
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(788.8, adu_y, stair_w, stair_d),
+            fill="#999999",
+            stroke="black",
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(393.8, adu_y + 40, ac_size, ac_size),
+            fill="#cccccc",
+            stroke="black",
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(788.8, adu_y + 40, ac_size, ac_size),
+            fill="#cccccc",
+            stroke="black",
+        )
+    )
+
+    # Parking pads
+    pad_w = 9 * SCALE
+    pad_h = 20 * SCALE
+    pad_y = 860
+    for x in (93.8, 193.8, 293.8, 518.8, 618.8, 718.8):
+        lines.append(
+            svg_rect(Rectangle(x, pad_y, pad_w, pad_h), fill="yellow", stroke="black")
+        )
+
+    # Trash pads
+    trash_w = 6 * SCALE
+    trash_h = 20 * SCALE
+    trash_y = 860
+    lines.append(
+        svg_rect(
+            Rectangle(390, trash_y, trash_w, trash_h), fill="brown", stroke="black"
+        )
+    )
+    lines.append(
+        svg_rect(
+            Rectangle(880, trash_y, trash_w, trash_h), fill="brown", stroke="black"
+        )
+    )
+
+    # Dimension lines
+    lines.append(dim_horizontal(0, center_x, 30, "Lot 2 Width: 45′"))
+    lines.append(dim_horizontal(center_x, width, 30, "Lot 1 Width: 46.76′"))
+    lines.append(dim_vertical(width - 20, 0, height, "Depth: 110.22′"))
+    duplex_back = front_y + duplex_h
+    lines.append(dim_vertical(243.8, duplex_back, adu_y, "20′ Building Separation"))
+    lines.append(dim_vertical(668.8, duplex_back, adu_y, "20′ Building Separation"))
+    lines.append(dim_horizontal(0, 80, front_y + duplex_h / 2, "8′ Side Setback"))
+    lines.append(
+        dim_horizontal(
+            center_x - 50,
+            87.8 + duplex_w,
+            front_y + duplex_h / 2,
+            "5′ Side Setback",
+        )
+    )
+    lines.append(
+        dim_horizontal(
+            center_x,
+            517.6,
+            front_y + duplex_h / 2,
+            "5′ Side Setback",
+        )
+    )
+    lines.append(
+        dim_horizontal(
+            width - 50,
+            517.6 + duplex_w,
+            front_y + duplex_h / 2,
+            "5′ Side Setback",
+        )
+    )
+    lines.append(
+        dim_vertical(
+            67.8 + porch_w / 2,
+            porch_y,
+            front_y,
+            "6′ Porch Offset (Encroaches)",
+        )
+    )
+    lines.append(
+        dim_vertical(
+            502.6 + porch_w / 2,
+            porch_y,
+            front_y,
+            "6′ Porch Offset (Encroaches)",
+        )
+    )
+
+    lines.append(svg_footer())
+    out.write_text("\n".join(lines))
+
+
+if __name__ == "__main__":
+    main()

--- a/output/siteplan_dual_lot.svg
+++ b/output/siteplan_dual_lot.svg
@@ -1,0 +1,77 @@
+<svg xmlns='http://www.w3.org/2000/svg' width='917.6' height='1102.2'>
+<rect x='0' y='0' width='467.6' height='1102.2' fill='none' stroke='black' stroke-width='2' />
+<rect x='467.6' y='0' width='450.0' height='1101.1' fill='none' stroke='black' stroke-width='2' />
+<line x1='467.6' y1='0' x2='467.6' y2='1102.2' stroke='black' />
+<line x1='0' y1='180' x2='467.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+<line x1='0' y1='991.2' x2='467.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+<line x1='467.6' y1='180' x2='917.6' y2='180' stroke='blue' stroke-dasharray='5,5' />
+<line x1='467.6' y1='991.2' x2='917.6' y2='991.2' stroke='blue' stroke-dasharray='5,5' />
+<line x1='80' y1='0' x2='80' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+<line x1='417.6' y1='0' x2='417.6' y2='1102.2' stroke='blue' stroke-dasharray='5,5' />
+<line x1='517.6' y1='0' x2='517.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+<line x1='867.6' y1='0' x2='867.6' y2='1101.1' stroke='blue' stroke-dasharray='5,5' />
+<rect x='87.8' y='180' width='330' height='280' fill='blue' stroke='black' />
+<rect x='517.6' y='180' width='330' height='280' fill='blue' stroke='black' />
+<rect x='67.8' y='120' width='60' height='100' fill='blue' stroke='black' />
+<rect x='237.8' y='120' width='60' height='100' fill='blue' stroke='black' />
+<rect x='502.6' y='120' width='60' height='100' fill='blue' stroke='black' />
+<rect x='672.6' y='120' width='60' height='100' fill='blue' stroke='black' />
+<rect x='93.8' y='660' width='300' height='200' fill='green' stroke='black' />
+<rect x='518.8' y='660' width='300' height='200' fill='green' stroke='black' />
+<rect x='393.8' y='660' width='30' height='60' fill='#999999' stroke='black' />
+<rect x='788.8' y='660' width='30' height='60' fill='#999999' stroke='black' />
+<rect x='393.8' y='700' width='30' height='30' fill='#cccccc' stroke='black' />
+<rect x='788.8' y='700' width='30' height='30' fill='#cccccc' stroke='black' />
+<rect x='93.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='193.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='293.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='518.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='618.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='718.8' y='860' width='90' height='200' fill='yellow' stroke='black' />
+<rect x='390' y='860' width='60' height='200' fill='brown' stroke='black' />
+<rect x='880' y='860' width='60' height='200' fill='brown' stroke='black' />
+<line x1='0' y1='30' x2='467.6' y2='30' stroke='black' stroke-dasharray='4,2' />
+<polygon points='0,25 0,35 -5,30' fill='black' />
+<polygon points='467.6,25 467.6,35 472.6,30' fill='black' />
+<text x='233.8' y='24' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>Lot 2 Width: 45′</text>
+<line x1='467.6' y1='30' x2='917.6' y2='30' stroke='black' stroke-dasharray='4,2' />
+<polygon points='467.6,25 467.6,35 462.6,30' fill='black' />
+<polygon points='917.6,25 917.6,35 922.6,30' fill='black' />
+<text x='692.6' y='24' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>Lot 1 Width: 46.76′</text>
+<line x1='897.6' y1='0' x2='897.6' y2='1102.2' stroke='black' stroke-dasharray='4,2' />
+<polygon points='892.6,0 902.6,0 897.6,-5' fill='black' />
+<polygon points='892.6,1102.2 902.6,1102.2 897.6,1107.2' fill='black' />
+<text x='903.6' y='551.1' fill='black' transform='rotate(-90 903.6,551.1)' font-size='10' font-family='sans-serif' text-anchor='middle'>Depth: 110.22′</text>
+<line x1='243.8' y1='460' x2='243.8' y2='660' stroke='black' stroke-dasharray='4,2' />
+<polygon points='238.8,460 248.8,460 243.8,455' fill='black' />
+<polygon points='238.8,660 248.8,660 243.8,665' fill='black' />
+<text x='249.8' y='560.0' fill='black' transform='rotate(-90 249.8,560.0)' font-size='10' font-family='sans-serif' text-anchor='middle'>20′ Building Separation</text>
+<line x1='668.8' y1='460' x2='668.8' y2='660' stroke='black' stroke-dasharray='4,2' />
+<polygon points='663.8,460 673.8,460 668.8,455' fill='black' />
+<polygon points='663.8,660 673.8,660 668.8,665' fill='black' />
+<text x='674.8' y='560.0' fill='black' transform='rotate(-90 674.8,560.0)' font-size='10' font-family='sans-serif' text-anchor='middle'>20′ Building Separation</text>
+<line x1='0' y1='320.0' x2='80' y2='320.0' stroke='black' stroke-dasharray='4,2' />
+<polygon points='0,315.0 0,325.0 -5,320.0' fill='black' />
+<polygon points='80,315.0 80,325.0 85,320.0' fill='black' />
+<text x='40.0' y='314.0' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>8′ Side Setback</text>
+<line x1='417.6' y1='320.0' x2='417.8' y2='320.0' stroke='black' stroke-dasharray='4,2' />
+<polygon points='417.6,315.0 417.6,325.0 412.6,320.0' fill='black' />
+<polygon points='417.8,315.0 417.8,325.0 422.8,320.0' fill='black' />
+<text x='417.70000000000005' y='314.0' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>5′ Side Setback</text>
+<line x1='467.6' y1='320.0' x2='517.6' y2='320.0' stroke='black' stroke-dasharray='4,2' />
+<polygon points='467.6,315.0 467.6,325.0 462.6,320.0' fill='black' />
+<polygon points='517.6,315.0 517.6,325.0 522.6,320.0' fill='black' />
+<text x='492.6' y='314.0' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>5′ Side Setback</text>
+<line x1='867.6' y1='320.0' x2='847.6' y2='320.0' stroke='black' stroke-dasharray='4,2' />
+<polygon points='867.6,315.0 867.6,325.0 862.6,320.0' fill='black' />
+<polygon points='847.6,315.0 847.6,325.0 852.6,320.0' fill='black' />
+<text x='857.6' y='314.0' fill='black' font-size='10' font-family='sans-serif' text-anchor='middle'>5′ Side Setback</text>
+<line x1='97.8' y1='120' x2='97.8' y2='180' stroke='black' stroke-dasharray='4,2' />
+<polygon points='92.8,120 102.8,120 97.8,115' fill='black' />
+<polygon points='92.8,180 102.8,180 97.8,185' fill='black' />
+<text x='103.8' y='150.0' fill='black' transform='rotate(-90 103.8,150.0)' font-size='10' font-family='sans-serif' text-anchor='middle'>6′ Porch Offset (Encroaches)</text>
+<line x1='532.6' y1='120' x2='532.6' y2='180' stroke='black' stroke-dasharray='4,2' />
+<polygon points='527.6,120 537.6,120 532.6,115' fill='black' />
+<polygon points='527.6,180 537.6,180 532.6,185' fill='black' />
+<text x='538.6' y='150.0' fill='black' transform='rotate(-90 538.6,150.0)' font-size='10' font-family='sans-serif' text-anchor='middle'>6′ Porch Offset (Encroaches)</text>
+</svg>

--- a/tests/test_example_siteplan_dual_lot.py
+++ b/tests/test_example_siteplan_dual_lot.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+import importlib
+
+
+def test_example_siteplan_dual_lot(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    module = importlib.import_module("examples.siteplan_dual_lot")
+    module.main()
+    svg = Path("output/siteplan_dual_lot.svg")
+    assert svg.exists()
+    content = svg.read_text()
+    # Ensure basic shapes and dimension labels exist
+    assert content.count("<rect") >= 10
+    assert "Lot 2 Width" in content
+    assert "Lot 1 Width" in content


### PR DESCRIPTION
## Summary
- extend dual lot example with helpers for dimension arrows
- place stair and A/C pad rectangles beside each ADU
- draw dimension lines with labels for lot size, setbacks and building separation
- update regression test for new labels

## Testing
- `flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6861f7ee795483308894d587c7f788ae